### PR TITLE
Pass correct error to error handler

### DIFF
--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -493,7 +493,7 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 		}
 		err = req.completePush()
 		if err != nil && req.statusCallback != nil {
-			req.statusCallback.Error(a.ID, req.remotefilepath, OpUpload, req.err)
+			req.statusCallback.Error(a.ID, req.remotefilepath, OpUpload, err)
 			return
 		}
 	}()


### PR DESCRIPTION
Fixes incorrect error struct being sent to handler see 
https://github.com/0chain/zboxcli/issues/15

Before fix (nil being passed down):
![image](https://user-images.githubusercontent.com/18306778/111890519-f706d880-89e1-11eb-96e9-6f78f0733e9f.png)

After fix (err struct being passed):
![image](https://user-images.githubusercontent.com/18306778/111890511-d76fb000-89e1-11eb-907b-2abc3b4ad5be.png)
