### PR TITLE
Disallow uploads to allocations requiring > 32 blobbers

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -60,19 +60,19 @@ type BlobberAllocationStats struct {
 }
 
 type ConsolidatedFileMeta struct {
-	Name           	string
-	Type           	string
-	Path           	string
-	LookupHash     	string
-	Hash           	string
-	MimeType       	string
-	Size           	int64
-	ActualFileSize 	int64
+	Name            string
+	Type            string
+	Path            string
+	LookupHash      string
+	Hash            string
+	MimeType        string
+	Size            int64
+	ActualFileSize  int64
 	ActualNumBlocks int64
-	EncryptedKey   	string
-	CommitMetaTxns 	[]fileref.CommitMetaTxn
-	Collaborators  	[]fileref.Collaborator
-	Attributes     	fileref.Attributes
+	EncryptedKey    string
+	CommitMetaTxns  []fileref.CommitMetaTxn
+	Collaborators   []fileref.Collaborator
+	Attributes      fileref.Attributes
 }
 
 type AllocationStats struct {
@@ -352,7 +352,6 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	uploadReq.filemeta.Attributes = attrs
 	uploadReq.remaining = uploadReq.filemeta.Size
 	uploadReq.thumbRemaining = uploadReq.filemeta.ThumbnailSize
-	uploadReq.isRepair = false
 	uploadReq.isUpdate = isUpdate
 	uploadReq.isRepair = isRepair
 	uploadReq.connectionID = zboxutil.NewConnectionId()
@@ -390,6 +389,10 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		uploadReq.filemeta.Hash = fileRef.ActualFileHash
 		uploadReq.uploadMask = (^found & uploadReq.uploadMask)
 		uploadReq.fullconsensus = float32(bits.TrailingZeros32(uploadReq.uploadMask + 1))
+	}
+
+	if !uploadReq.IsFullConsensusSupported() {
+		return fmt.Errorf("allocation requires a greater number of blobbers than is supported. reduce number of data or parity shards and try again")
 	}
 
 	go func() {

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -32,6 +32,10 @@ var (
 	notInitialized = common.NewError("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
 )
 
+var GetFileInfo = func(localpath string) (os.FileInfo, error) {
+	return os.Stat(localpath)
+}
+
 type BlobberAllocationStats struct {
 	BlobberID        string
 	BlobberURL       string
@@ -315,7 +319,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		return notInitialized
 	}
 
-	fileInfo, err := os.Stat(localpath)
+	fileInfo, err := GetFileInfo(localpath)
 	if err != nil {
 		return fmt.Errorf("Local file error: %s", err.Error())
 	}
@@ -358,7 +362,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	uploadReq.statusCallback = status
 	uploadReq.datashards = a.DataShards
 	uploadReq.parityshards = a.ParityShards
-	uploadReq.uploadMask = uint32((1 << uint32(len(a.Blobbers))) - 1)
+	uploadReq.setUploadMask(len(a.Blobbers))
 	uploadReq.consensusThresh = (float32(a.DataShards) * 100) / float32(a.DataShards+a.ParityShards)
 	uploadReq.fullconsensus = float32(a.DataShards + a.ParityShards)
 	uploadReq.isEncrypted = encryption

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -396,7 +396,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	}
 
 	if !uploadReq.IsFullConsensusSupported() {
-		return fmt.Errorf("allocation requires a greater number of blobbers than is supported. reduce number of data or parity shards and try again")
+		return fmt.Errorf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported())
 	}
 
 	go func() {

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -23,7 +23,7 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanImplicitLimit32(t *testing.T) 
 	var file fileref.Attributes
 	err := allocation.uploadOrUpdateFile("", "/", nil, false, "", false, false, file)
 
-	var expectedErr = "allocation requires a greater number of blobbers than is supported. reduce number of data or parity shards and try again"
+	var expectedErr = "allocation requires [33] blobbers, which is greater than the maximum permitted number of [32]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
 	} else if err.Error() != expectedErr {
@@ -31,7 +31,7 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanImplicitLimit32(t *testing.T) 
 	}
 }
 
-func TestThrowErrorWhenBlobbersRequiredGreaterThanLimit(t *testing.T) {
+func TestThrowErrorWhenBlobbersRequiredGreaterThanExplicitLimit(t *testing.T) {
 	setupMocks()
 
 	var maxNumOfBlobbers = 10
@@ -47,7 +47,7 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanLimit(t *testing.T) {
 	var file fileref.Attributes
 	err := allocation.uploadOrUpdateFile("", "/", nil, false, "", false, false, file)
 
-	var expectedErr = "allocation requires a greater number of blobbers than is supported. reduce number of data or parity shards and try again"
+	var expectedErr = "allocation requires [11] blobbers, which is greater than the maximum permitted number of [10]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
 	} else if err.Error() != expectedErr {

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -1,0 +1,90 @@
+package sdk
+
+import (
+	"github.com/0chain/gosdk/zboxcore/blockchain"
+	"github.com/0chain/gosdk/zboxcore/fileref"
+	"os"
+	"testing"
+)
+
+func TestThrowErrorWhenBlobbersRequiredGreaterThanImplicitLimit32(t *testing.T) {
+	setupMocks()
+
+	var maxNumOfBlobbers = 33
+
+	var allocation = &Allocation{}
+	var blobbers = make([]*blockchain.StorageNode, maxNumOfBlobbers)
+	allocation.initialized = true
+	sdkInitialized = true
+	allocation.Blobbers = blobbers
+	allocation.DataShards = 16
+	allocation.ParityShards = 17
+
+	var file fileref.Attributes
+	err := allocation.uploadOrUpdateFile("", "/", nil, false, "", false, false, file)
+
+	var expectedErr = "allocation requires a greater number of blobbers than is supported. reduce number of data or parity shards and try again"
+	if err == nil {
+		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
+	} else if err.Error() != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	}
+}
+
+func TestThrowErrorWhenBlobbersRequiredGreaterThanLimit(t *testing.T) {
+	setupMocks()
+
+	var maxNumOfBlobbers = 10
+
+	var allocation = &Allocation{}
+	var blobbers = make([]*blockchain.StorageNode, maxNumOfBlobbers)
+	allocation.initialized = true
+	sdkInitialized = true
+	allocation.Blobbers = blobbers
+	allocation.DataShards = 5
+	allocation.ParityShards = 6
+
+	var file fileref.Attributes
+	err := allocation.uploadOrUpdateFile("", "/", nil, false, "", false, false, file)
+
+	var expectedErr = "allocation requires a greater number of blobbers than is supported. reduce number of data or parity shards and try again"
+	if err == nil {
+		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
+	} else if err.Error() != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	}
+}
+
+func TestDoNotThrowErrorWhenBlobbersRequiredLessThanLimit(t *testing.T) {
+	setupMocks()
+
+	var maxNumOfBlobbers = 10
+
+	var allocation = &Allocation{}
+	var blobbers = make([]*blockchain.StorageNode, maxNumOfBlobbers)
+	allocation.initialized = true
+	sdkInitialized = true
+	allocation.Blobbers = blobbers
+	allocation.DataShards = 5
+	allocation.ParityShards = 4
+
+	var file fileref.Attributes
+	err := allocation.uploadOrUpdateFile("", "/", nil, false, "", false, false, file)
+
+	if err != nil {
+		t.Errorf("uploadOrUpdateFile() = expected no error but was %v", err)
+	}
+}
+
+func setupMocks() {
+	GetFileInfo = func(localpath string) (os.FileInfo, error) {
+		return new(MockFile), nil
+	}
+}
+
+type MockFile struct {
+	os.FileInfo
+	size int64
+}
+
+func (m MockFile) Size() int64 { return 10 }

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -617,3 +617,7 @@ func (req *UploadRequest) IsFullConsensusSupported() bool {
 
 	return maxBlobbers >= uint32(req.fullconsensus)
 }
+
+func (req *UploadRequest) setUploadMask(numBlobbers int) {
+	req.uploadMask = uint32((1 << uint32(numBlobbers)) - 1)
+}

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -103,6 +103,10 @@ type UploadRequest struct {
 	Consensus
 }
 
+func (req *UploadRequest) setUploadMask(numBlobbers int) {
+	req.uploadMask = uint32((1 << uint32(numBlobbers)) - 1)
+}
+
 func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.StorageNode, file *fileref.FileRef, uploadCh chan []byte, uploadThumbCh chan []byte, wg *sync.WaitGroup) {
 	bodyReader, bodyWriter := io.Pipe()
 	formWriter := multipart.NewWriter(bodyWriter)
@@ -616,8 +620,4 @@ func (req *UploadRequest) IsFullConsensusSupported() bool {
 	var maxBlobbers = uint32(bits.OnesCount32(req.uploadMask))
 
 	return maxBlobbers >= uint32(req.fullconsensus)
-}
-
-func (req *UploadRequest) setUploadMask(numBlobbers int) {
-	req.uploadMask = uint32((1 << uint32(numBlobbers)) - 1)
 }

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -617,7 +617,11 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 }
 
 func (req *UploadRequest) IsFullConsensusSupported() bool {
-	var maxBlobbers = uint32(bits.OnesCount32(req.uploadMask))
+	var maxBlobbers = req.GetMaxBlobbersSupported()
 
 	return maxBlobbers >= uint32(req.fullconsensus)
+}
+
+func (req *UploadRequest) GetMaxBlobbersSupported() uint32 {
+	return uint32(bits.OnesCount32(req.uploadMask))
 }

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -611,3 +611,9 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 
 	return
 }
+
+func (req *UploadRequest) IsFullConsensusSupported() bool {
+	var maxBlobbers = uint32(bits.OnesCount32(req.uploadMask))
+
+	return maxBlobbers >= uint32(req.fullconsensus)
+}

--- a/zboxcore/sdk/uploadworker_test.go
+++ b/zboxcore/sdk/uploadworker_test.go
@@ -1,0 +1,65 @@
+package sdk
+
+import (
+	"testing"
+)
+
+func TestMaxBlobbersRequiredGreaterThanImplicitLimit32(t *testing.T) {
+	var maxNumOfBlobbers = 33
+
+	var req = &UploadRequest{}
+	req.setUploadMask(maxNumOfBlobbers)
+	req.fullconsensus = float32(maxNumOfBlobbers)
+
+	if req.IsFullConsensusSupported() {
+		t.Errorf("IsFullConsensusSupported() = %v, want %v", true, false)
+	}
+}
+
+func TestNaxBlobbersRequiredEqualToImplicitLimit32(t *testing.T) {
+	var maxNumOfBlobbers = 32
+
+	var req = &UploadRequest{}
+	req.setUploadMask(maxNumOfBlobbers)
+	req.fullconsensus = float32(maxNumOfBlobbers)
+
+	if !req.IsFullConsensusSupported() {
+		t.Errorf("IsFullConsensusSupported() = %v, want %v", false, true)
+	}
+}
+
+func TestNumBlobbersRequiredGreaterThanMask(t *testing.T) {
+	var maxNumOfBlobbers = 5
+
+	var req = &UploadRequest{}
+	req.setUploadMask(maxNumOfBlobbers)
+	req.fullconsensus = float32(6)
+
+	if req.IsFullConsensusSupported() {
+		t.Errorf("IsFullConsensusSupported() = %v, want %v", true, false)
+	}
+}
+
+func TestNumBlobbersRequiredLessThanMask(t *testing.T) {
+	var maxNumOfBlobbers = 5
+
+	var req = &UploadRequest{}
+	req.setUploadMask(maxNumOfBlobbers)
+	req.fullconsensus = float32(4)
+
+	if !req.IsFullConsensusSupported() {
+		t.Errorf("IsFullConsensusSupported() = %v, want %v", false, true)
+	}
+}
+
+func TestNumBlobbersRequiredZero(t *testing.T) {
+	var maxNumOfBlobbers = 5
+
+	var req = &UploadRequest{}
+	req.setUploadMask(maxNumOfBlobbers)
+	req.fullconsensus = float32(0)
+
+	if !req.IsFullConsensusSupported() {
+		t.Errorf("IsFullConsensusSupported() = %v, want %v", false, true)
+	}
+}


### PR DESCRIPTION
As discussed in https://github.com/0chain/zboxcli/issues/14 the SDK implicitly supports max 32 blobbers per allocation due to the use of a 32-bit upload mask. 
Today, the SDK will either silently drop EC shards or never meet the required consensus when using these allocations.
Added validation to error out when an allocation requiring > 32 blobbers is used therefore preventing incomplete data persistence  

Validation:
20/30 EC combo: (previously would have dropped shards)
40/60 EC combo: (previously would have never met the required consensus)
![image](https://user-images.githubusercontent.com/18306778/112216753-c7421580-8c19-11eb-925f-4ea41e3c3cc5.png)

10/20 EC combo:
![image](https://user-images.githubusercontent.com/18306778/112216637-a7aaed00-8c19-11eb-9310-ee9f7833c82e.png)

