### PR TITLE
Ensure method of signature generation in gsdk matches that of the blobber

### DIFF
--- a/zboxcore/zboxutil/http.go
+++ b/zboxcore/zboxutil/http.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/client"
@@ -144,7 +145,7 @@ func setClientInfo(req *http.Request) {
 func setClientInfoWithSign(req *http.Request, allocation string) error {
 	setClientInfo(req)
 
-	sign, err := client.Sign(allocation)
+	sign, err := client.Sign(encryption.Hash(allocation))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On the **goSDK** side we are signing the raw allocation id
https://github.com/0chain/gosdk/blob/a490ac8f5ea3668e679d1a6caa261cc2a8eff651/zboxcore/zboxutil/http.go#L147

On the **blobber** side we are signing the HASH of the allocation id and comparing with the signature in the request to see if they match (which they never will) resulting in a 400 every request
(https://github.com/0chain/blobber/blob/7453db5e72b56988f9d120f1759f09b4fa4d4ca6/code/go/0chain.net/blobbercore/handler/storage_handler.go#L714)

This PR brings the two inline and will prevent the 400