### PR TITLE
Update allocation representation

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -65,7 +65,6 @@ type BlobberAllocationStats struct {
 		ReadPrice    int    `json:"ReadPrice"`
 		WritePrice   int    `json:"WritePrice"`
 	} `json:"Terms"`
-	PayerID string `json:"PayerID"`
 }
 
 type ConsolidatedFileMeta struct {


### PR DESCRIPTION
The logic behind the field is changed in the first place (blobber node).
Also the field should barely be used/viewed outside blobbers.

For more detail:
https://github.com/0chain/blobber/issues/161