### PR TITLE
better readability of logs

### DIFF
--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -50,7 +50,7 @@ type Logger struct {
 	fWriter  io.Writer
 }
 
-// Init - Initialize loggind
+// Init - Initialize logging
 func (l *Logger) Init(lvl int, prefix string) {
 	l.SetLevel(lvl)
 	l.prefix = prefix
@@ -63,6 +63,26 @@ func (l *Logger) Init(lvl int, prefix string) {
 // SetLevel - Configures the log level. Higher the number more verbose.
 func (l *Logger) SetLevel(lvl int) {
 	l.lvl = lvl
+}
+
+// syncPrefixes - syncs the logger prefixes
+func syncPrefixes(maxPrefixLen int, loggers []*Logger) {
+	for _, lgr := range loggers {
+		if maxPrefixLen-len(lgr.prefix) > 0 {
+			lgr.prefix = fmt.Sprintf("%-*s", maxPrefixLen, lgr.prefix)
+		}
+	}
+}
+
+// SyncLoggers - syncs the loggers
+func SyncLoggers(loggers []*Logger) {
+	maxPrefixLen := 0
+	for _, lgr := range loggers {
+		if len(lgr.prefix) > maxPrefixLen {
+			maxPrefixLen = len(lgr.prefix)
+		}
+	}
+	syncPrefixes(maxPrefixLen, loggers)
 }
 
 // SetLogFile - Writes log to the file. set verbose false disables log to os.Stderr

--- a/zboxcore/logger/logger.go
+++ b/zboxcore/logger/logger.go
@@ -6,5 +6,5 @@ var defaultLogLevel = logger.DEBUG
 var Logger logger.Logger
 
 func init() {
-	Logger.Init(defaultLogLevel, "0box-sdk")
+	Logger.Init(defaultLogLevel, "0box-sdk       ")
 }

--- a/zboxcore/logger/logger.go
+++ b/zboxcore/logger/logger.go
@@ -6,5 +6,5 @@ var defaultLogLevel = logger.DEBUG
 var Logger logger.Logger
 
 func init() {
-	Logger.Init(defaultLogLevel, "0box-sdk       ")
+	Logger.Init(defaultLogLevel, "0box-sdk")
 }

--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/0chain/gosdk/core/logger"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -58,6 +59,7 @@ func SetLogLevel(lvl int) {
 	Logger.SetLevel(lvl)
 }
 
+// SetLogFile
 // logFile - Log file
 // verbose - true - console output; false - no console output
 func SetLogFile(logFile string, verbose bool) {
@@ -67,6 +69,10 @@ func SetLogFile(logFile string, verbose bool) {
 	}
 	Logger.SetLogFile(f, verbose)
 	Logger.Info("******* Storage SDK Version: ", version.VERSIONSTR, " *******")
+}
+
+func GetLogger() *logger.Logger {
+	return &Logger
 }
 
 func InitStorageSDK(clientJson string, blockWorker string, chainID string, signatureScheme string, preferredBlobbers []string) error {

--- a/zcncore/wallet.go
+++ b/zcncore/wallet.go
@@ -205,7 +205,7 @@ func checkSdkInit() error {
 func checkWalletConfig() error {
 	if !_config.isValidWallet || _config.wallet.ClientID == "" {
 		Logger.Error("wallet info not found. returning error.")
-		return fmt.Errorf("wallet info not found. set wallet info.")
+		return fmt.Errorf("wallet info not found. set wallet info")
 	}
 	return nil
 }
@@ -274,6 +274,10 @@ func SetLogFile(logFile string, verbose bool) {
 	}
 	Logger.SetLogFile(f, verbose)
 	Logger.Info("******* Wallet SDK Version:", version.VERSIONSTR, " *******")
+}
+
+func GetLogger() *logger.Logger {
+	return &Logger
 }
 
 // CloseLog closes log file


### PR DESCRIPTION
when running zboxcli, logs look like this 
```
0chain-core-sdk [INFO]   2021/06/21 02:43:31.089961 wallet.go:276: ******* Wallet SDK Version:v1.2.6 *******
0box-sdk [INFO]   2021/06/21 02:43:31.090784 sdk.go:69: ******* Storage SDK Version: v1.2.6 *******
0chain-core-sdk [INFO]   2021/06/21 02:43:31.161371 wallet.go:359: *******  Wallet SDK Version:v1.2.6 *******
0box-sdk [DEBUG]  2021/06/21 02:43:31.175406 networkworker.go:98: Get network result:{"miners":["http://198.18.0.71/","http://198.18.0.72/","http://198.18.0.74/","http://198.18.0.73/"],"sharders":["http://198.18.0.81/"]}
```

with this small change, logs would look like this. 
```
0chain-core-sdk [INFO]   2021/06/21 03:09:32.861001 wallet.go:276: ******* Wallet SDK Version:v1.2.6 *******
0box-sdk        [INFO]   2021/06/21 03:09:32.861517 sdk.go:70: ******* Storage SDK Version: v1.2.6 *******
0chain-core-sdk [INFO]   2021/06/21 03:09:32.880253 wallet.go:359: *******  Wallet SDK Version:v1.2.6 *******
0box-sdk        [DEBUG]  2021/06/21 03:09:32.889983 networkworker.go:98: Get network result:{"miners":["http://198.18.0.71/","http://198.18.0.72/","http://198.18.0.74/","http://198.18.0.73/"],"sharders":["http://198.18.0.81/"]}

```