### PR TITLE
Add immutable to allocation and update allocation

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -141,6 +141,7 @@ type Allocation struct {
 	Blobbers       []*blockchain.StorageNode `json:"blobbers"`
 	Stats          *AllocationStats          `json:"stats"`
 	TimeUnit       time.Duration             `json:"time_unit"`
+	IsImmutable    bool                      `json:"is_immutable"`
 
 	// BlobberDetails contains real terms used for the allocation.
 	// If the allocation has updated, then terms calculated using

--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -841,7 +841,7 @@ func CreateAllocationForOwner(owner, ownerpublickey string,
 }
 
 func UpdateAllocation(size int64, expiry int64, allocationID string,
-	lock int64) (hash string, err error) {
+	lock int64, setImmutable bool) (hash string, err error) {
 
 	if !sdkInitialized {
 		return "", sdkNotInitialized
@@ -852,6 +852,7 @@ func UpdateAllocation(size int64, expiry int64, allocationID string,
 	updateAllocationRequest["id"] = allocationID
 	updateAllocationRequest["size"] = size
 	updateAllocationRequest["expiration_date"] = expiry
+	updateAllocationRequest["set_immutable"] = setImmutable
 
 	sn := transaction.SmartContractTxnData{
 		Name:      transaction.STORAGESC_UPDATE_ALLOCATION,


### PR DESCRIPTION
Add immutable field to allocation object
Pass through a `setImmutable` field on update allocation.
Matches with 0chain https://github.com/0chain/0chain/pull/375 and zboxcli changes https://github.com/0chain/zboxcli/pull/51.