### PR TITLE
remodelling error package!

### DIFF
--- a/core/common/errors.go
+++ b/core/common/errors.go
@@ -67,6 +67,11 @@ func NewError(code string, msg string) *Error {
 	}
 }
 
+// NewErrorMessage - creates a new error with just message
+func NewErrorMessage(msg string) *Error {
+	return NewError("", msg)
+}
+
 func getErrorLocation() string {
 	_, file, line, _ := runtime.Caller(2)
 	return fmt.Sprintf("%s:%d", file, line)

--- a/core/common/errors.go
+++ b/core/common/errors.go
@@ -2,21 +2,67 @@ package common
 
 import (
 	"fmt"
+	"runtime"
 )
 
 /*Error type for a new application error */
 type Error struct {
-	Code string `json:"code,omitempty"`
-	Msg  string `json:"msg"`
+	Code     string `json:"code,omitempty"`
+	Msg      string `json:"msg"`
+	Location string `json:"location"`
 }
 
 func (err *Error) Error() string {
-	return fmt.Sprintf("%s: %s", err.Code, err.Msg)
+	if err.Code == "" {
+		return fmt.Sprintf("%s %s", err.Location, err.Msg)
+	}
+	return fmt.Sprintf("%s %s: %s", err.Location, err.Code, err.Msg)
+}
+
+type withError struct {
+	previous error
+	current  error
+}
+
+func (w *withError) Error() string {
+	return w.current.Error() + "\n" + w.previous.Error()
+}
+
+// WrapWithError wrap the previous error with current error
+func WrapWithError(previous error, current error) error {
+	if current == nil {
+		return previous
+	}
+
+	return &withError{
+		previous: previous,
+		current:  current,
+	}
+}
+
+// WrapWithError wrap the previous error with current error message
+func WrapWithMessage(previous error, msg string) error {
+	return &withError{
+		previous: previous,
+		current: &Error{
+			Msg:      msg,
+			Location: getErrorLocation(),
+		},
+	}
 }
 
 /*NewError - create a new error */
 func NewError(code string, msg string) *Error {
-	return &Error{Code: code, Msg: msg}
+	return &Error{
+		Code:     code,
+		Msg:      msg,
+		Location: getErrorLocation(),
+	}
+}
+
+func getErrorLocation() string {
+	_, file, line, _ := runtime.Caller(2)
+	return fmt.Sprintf("%s:%d", file, line)
 }
 
 /*InvalidRequest - create error messages that are needed when validating request input */

--- a/core/common/errors.go
+++ b/core/common/errors.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 /*Error type for a new application error */
@@ -17,6 +18,12 @@ func (err *Error) Error() string {
 		return fmt.Sprintf("%s %s", err.Location, err.Msg)
 	}
 	return fmt.Sprintf("%s %s: %s", err.Location, err.Code, err.Msg)
+}
+
+// TopLevelError since errors can be wrapped and stacked,
+// it's necessary to get the top level error for tests and validations
+func TopLevelError(err error) string {
+	return strings.SplitN(strings.Split(err.Error(), "\n")[0], " ", 2)[1]
 }
 
 type withError struct {

--- a/core/common/errors/errors.go
+++ b/core/common/errors/errors.go
@@ -1,4 +1,4 @@
-package common
+package errors
 
 import (
 	"fmt"

--- a/core/common/errors/errors.go
+++ b/core/common/errors/errors.go
@@ -19,23 +19,23 @@ func (err *Error) Error() string {
 	return fmt.Sprintf("%s %s: %s", err.Location, err.Code, err.Msg)
 }
 
-func (err *Error) topLevelError() string {
+func (err *Error) top() string {
 	if err.Code == "" {
 		return err.Msg
 	}
 	return fmt.Sprintf("%s: %s", err.Code, err.Msg)
 }
 
-// TopLevelError since errors can be wrapped and stacked,
+// Top since errors can be wrapped and stacked,
 // it's necessary to get the top level error for tests and validations
-func TopLevelError(err error) string {
+func Top(err error) string {
 	switch t := err.(type) {
 	case *Error:
-		return t.topLevelError()
+		return t.top()
 	case *withError:
 		switch ct := t.current.(type) {
 		case *Error:
-			return ct.topLevelError()
+			return ct.top()
 		default:
 			return err.Error()
 		}
@@ -60,8 +60,8 @@ func (w *withError) Error() string {
 	return retError
 }
 
-// WrapError wrap the previous error with current error/ message
-func WrapError(previous error, current interface{}) error {
+// Wrap wrap the previous error with current error/ message
+func Wrap(previous error, current interface{}) error {
 	if current == nil {
 		return previous
 	}
@@ -93,16 +93,16 @@ func WrapError(previous error, current interface{}) error {
 }
 
 /*
-NewError - create a new error 
-two arguments can be passed! 
-1. code 
+New - create a new error
+two arguments can be passed!
+1. code
 2. message
 if only one argument is passed its considered as message
-if two arguments are passed then 
-	first argument is considered for code and 
+if two arguments are passed then
+	first argument is considered for code and
 	second argument is considered for message
 */
-func NewError(args ...string) *Error {
+func New(args ...string) *Error {
 	switch len(args) {
 	case 1:
 		return &Error{
@@ -130,7 +130,7 @@ func getErrorLocation(level int) string {
 	return fmt.Sprintf("%s:%d", file, line)
 }
 
-/*InvalidRequest - create error messages that are needed when validating request input */
-func InvalidRequest(msg string) error {
-	return NewError("invalid_request", fmt.Sprintf("Invalid request (%v)", msg))
-}
+// /*InvalidRequest - create error messages that are needed when validating request input */
+// func InvalidRequest(msg string) error {
+// 	return New("invalid_request", fmt.Sprintf("Invalid request (%v)", msg))
+// }

--- a/core/common/errors/errors_test.go
+++ b/core/common/errors/errors_test.go
@@ -1,0 +1,164 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type newErrorTestCase struct {
+	about           string
+	args            []string
+	expectedCode    string
+	expectedMessage string
+}
+
+func getNewErrorTestCase() []newErrorTestCase {
+	return []newErrorTestCase{
+		{
+			about:           "creating an error with code and msg.",
+			args:            []string{"500", "This is a very big error! Beware of it!"},
+			expectedCode:    "500",
+			expectedMessage: "This is a very big error! Beware of it!",
+		},
+		{
+			about:           "creating an error with empty code and msg.",
+			args:            []string{"", "This is a very big error! Beware of it!"},
+			expectedCode:    "",
+			expectedMessage: "This is a very big error! Beware of it!",
+		},
+		{
+			about:           "creating an error with code and empty msg.",
+			args:            []string{"401", ""},
+			expectedCode:    "401",
+			expectedMessage: "",
+		},
+		{
+			about:           "creating an error with just msg.",
+			args:            []string{"This is a short error!"},
+			expectedCode:    "",
+			expectedMessage: "This is a short error!",
+		},
+		{
+			about:           "creating an error with not allowed parameters",
+			args:            []string{"code", "message", "third"},
+			expectedCode:    "incorrect_usage",
+			expectedMessage: "you should at least pass message to create a proper error!",
+		},
+		{
+			about:           "creating an error with not allowed parameters",
+			args:            []string{"code", "message", "third", "fourth"},
+			expectedCode:    "incorrect_usage",
+			expectedMessage: "you should at least pass message to create a proper error!",
+		},
+		{
+			about:           "creating an error with empty parameters",
+			args:            []string{},
+			expectedCode:    "incorrect_usage",
+			expectedMessage: "you should at least pass message to create a proper error!",
+		},
+	}
+}
+
+func TestNew(t *testing.T) {
+	for _, tc := range getNewErrorTestCase() {
+		t.Run(tc.about, func(t *testing.T) {
+			err := New(tc.args...)
+
+			require.Equal(t, tc.expectedCode, err.Code)
+			require.Equal(t, tc.expectedMessage, err.Msg)
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	for _, tc := range getNewErrorTestCase() {
+		t.Run(tc.about, func(t *testing.T) {
+			err := New(tc.args...)
+
+			require.Contains(t, err.Error(), tc.expectedMessage)
+		})
+	}
+}
+
+type wrapTopTestCase struct {
+	about              string
+	testCase           []interface{}
+	expectedTopMessage string
+}
+
+func getWrapTopTestCases() []wrapTopTestCase {
+	return []wrapTopTestCase{
+		{
+			about: "wrapping all errors",
+			testCase: []interface{}{
+				New("500", "This is a very big error! Beware of it!"),
+				New("", "This is a very big error! Beware of it!"),
+				New("401", ""),
+				New("This is a short error!"),
+				New("code", "message", "third"),
+				New("code", "message", "third", "fourth"),
+				New(),
+				errors.New("error created from err package"),
+				fmt.Errorf("%s", "error created from fmt package"),
+				nil,
+			},
+			expectedTopMessage: "incorrect_usage: you should at least pass message to properly wrap the current error!",
+		},
+		{
+			about: "wrapping all messages",
+			testCase: []interface{}{
+				"This is a very \"big\" error! Beware of it!",
+				"This is a very 'big' error! Beware of it!",
+				"This is a short error!",
+				"",
+			},
+			expectedTopMessage: "incorrect_usage: you should at least pass message to properly wrap the current error!",
+		},
+		{
+			about: "wrapping errors and messages",
+			testCase: []interface{}{
+				New("500", "This is a very big error! Beware of it!"),
+				"This is a very \"big\" error! Beware of it!",
+				New("401", ""),
+				"This is a very 'big' error! Beware of it!",
+				New("This is a short error!"),
+				"",
+				nil,
+				New("code", "message", "third"),
+				"This is a short error!",
+				New("code", "message", "third", "fourth"),
+				New(),
+				New("", "This is a very big error! Beware of it!"),
+			},
+			expectedTopMessage: "This is a very big error! Beware of it!",
+		},
+	}
+}
+
+func TestWrap(t *testing.T) {
+	for _, gtc := range getWrapTopTestCases() {
+		t.Run(gtc.about, func(t *testing.T) {
+			var wrappedError error
+			for _, tc := range gtc.testCase {
+				wrappedError = Wrap(wrappedError, tc)
+			}
+			require.Equal(t, len(gtc.testCase), len(strings.Split(wrappedError.Error(), "\n")))
+		})
+	}
+}
+
+func TestTop(t *testing.T) {
+	for _, gtc := range getWrapTopTestCases() {
+		t.Run(gtc.about, func(t *testing.T) {
+			var wrappedError error
+			for _, tc := range gtc.testCase {
+				wrappedError = Wrap(wrappedError, tc)
+			}
+			require.Equal(t, gtc.expectedTopMessage, Top(wrappedError))
+		})
+	}
+}

--- a/core/common/misc.go
+++ b/core/common/misc.go
@@ -79,7 +79,7 @@ func (wp WhoPays) Validate() (err error) {
 	case WhoPays3rdParty, WhoPaysOwner:
 		return // ok
 	}
-	return errors.NewError("validate_error", fmt.Sprintf("unknown WhoPays value: %d", int(wp)))
+	return errors.New("validate_error", fmt.Sprintf("unknown WhoPays value: %d", int(wp)))
 }
 
 // Parse given string and set the WhoPays by it. Or return parsing error.
@@ -91,7 +91,7 @@ func (wp *WhoPays) Parse(val string) (err error) {
 	case "3rd_party":
 		(*wp) = WhoPays3rdParty
 	default:
-		err = errors.NewError("parse_error", fmt.Sprintf("empty or unknown 'who_pays' value: %q", val))
+		err = errors.New("parse_error", fmt.Sprintf("empty or unknown 'who_pays' value: %q", val))
 	}
 	return
 }

--- a/core/common/misc.go
+++ b/core/common/misc.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/0chain/gosdk/core/common/errors"
 )
 
 const tokenUnit = 10000000000.0
@@ -77,7 +79,7 @@ func (wp WhoPays) Validate() (err error) {
 	case WhoPays3rdParty, WhoPaysOwner:
 		return // ok
 	}
-	return NewError("validate_error", fmt.Sprintf("unknown WhoPays value: %d", int(wp)))
+	return errors.NewError("validate_error", fmt.Sprintf("unknown WhoPays value: %d", int(wp)))
 }
 
 // Parse given string and set the WhoPays by it. Or return parsing error.
@@ -89,7 +91,7 @@ func (wp *WhoPays) Parse(val string) (err error) {
 	case "3rd_party":
 		(*wp) = WhoPays3rdParty
 	default:
-		err = NewError("parse_error", fmt.Sprintf("empty or unknown 'who_pays' value: %q", val))
+		err = errors.NewError("parse_error", fmt.Sprintf("empty or unknown 'who_pays' value: %q", val))
 	}
 	return
 }

--- a/core/common/misc.go
+++ b/core/common/misc.go
@@ -77,7 +77,7 @@ func (wp WhoPays) Validate() (err error) {
 	case WhoPays3rdParty, WhoPaysOwner:
 		return // ok
 	}
-	return fmt.Errorf("unknown WhoPays value: %d", int(wp))
+	return NewError("validate_error", fmt.Sprintf("unknown WhoPays value: %d", int(wp)))
 }
 
 // Parse given string and set the WhoPays by it. Or return parsing error.
@@ -89,7 +89,7 @@ func (wp *WhoPays) Parse(val string) (err error) {
 	case "3rd_party":
 		(*wp) = WhoPays3rdParty
 	default:
-		err = fmt.Errorf("empty or unknown 'who_pays' value: %q", val)
+		err = NewError("parse_error", fmt.Sprintf("empty or unknown 'who_pays' value: %q", val))
 	}
 	return
 }

--- a/core/transaction/entity.go
+++ b/core/transaction/entity.go
@@ -172,7 +172,7 @@ func (t *Transaction) VerifyTransaction(verifyHandler VerifyFunc) (bool, error) 
 	hash := t.Hash
 	t.ComputeHashData()
 	if t.Hash != hash {
-		return false, fmt.Errorf(`{"error":"hash_mismatch", "expected":"%v", "actual":%v"}`, t.Hash, hash)
+		return false, common.NewError("verify_transaction", fmt.Sprintf(`{"error":"hash_mismatch", "expected":"%v", "actual":%v"}`, t.Hash, hash))
 	}
 	return verifyHandler(t.Signature, t.Hash, t.PublicKey)
 }
@@ -200,57 +200,64 @@ func sendTransactionToURL(url string, txn *Transaction, wg *sync.WaitGroup) ([]b
 	if postResponse.StatusCode >= 200 && postResponse.StatusCode <= 299 {
 		return []byte(postResponse.Body), nil
 	}
-	return nil, common.NewError("transaction_send_error", postResponse.Body)
+	return nil, common.WrapWithError(err, common.NewError("transaction_send_error", postResponse.Body))
 }
 
 func VerifyTransaction(txnHash string, sharders []string) (*Transaction, error) {
 	numSharders := len(sharders)
 	numSuccess := 0
 	var retTxn *Transaction
+	var customError error
 	for _, sharder := range sharders {
 		url := fmt.Sprintf("%v/%v%v", sharder, TXN_VERIFY_URL, txnHash)
 		req, err := util.NewHTTPGetRequest(url)
+		if err != nil {
+			customError = common.WrapWithError(customError, err)
+			numSharders--
+			continue
+		}
 		response, err := req.Get()
 		if err != nil {
-			//Logger.Error("Error getting transaction confirmation", err.Error())
+			customError = common.WrapWithError(customError, err)
 			numSharders--
+			continue
 		} else {
 			if response.StatusCode != 200 {
+				customError = common.WrapWithError(customError, err)
 				continue
 			}
 			contents := response.Body
 			var objmap map[string]json.RawMessage
 			err = json.Unmarshal([]byte(contents), &objmap)
 			if err != nil {
-				//Logger.Error("Error unmarshalling response", err.Error())
+				customError = common.WrapWithError(customError, err)
 				continue
 			}
 			if _, ok := objmap["txn"]; !ok {
-				//Logger.Info("Not transaction information. Only block summary.", url, contents)
 				if _, ok := objmap["block_hash"]; ok {
 					numSuccess++
-					continue
+				} else {
+					customError = common.WrapWithMessage(customError, fmt.Sprintf("Sharder does not have the block summary with url: %s, contents: %s", url, contents))
 				}
-				//Logger.Info("Sharder does not have the block summary", url, contents)
 				continue
 			}
 			txn := &Transaction{}
 			err = json.Unmarshal(objmap["txn"], txn)
 			if err != nil {
-				//Logger.Error("Error unmarshalling to get transaction response", err.Error())
+				customError = common.WrapWithError(customError, err)
+				continue
 			}
 			if len(txn.Signature) > 0 {
 				retTxn = txn
 			}
-
 			numSuccess++
 		}
 	}
-	if numSharders == 0 || float64(numSuccess*1.0/numSharders) > float64(0.5) {
+	if numSharders == 0 || float64(numSuccess*1.0/numSharders) > 0.5 {
 		if retTxn != nil {
 			return retTxn, nil
 		}
-		return nil, ErrNoTxnDetail
+		return nil, common.WrapWithError(customError, ErrNoTxnDetail)
 	}
-	return nil, common.NewError("transaction_not_found", "Transaction was not found on any of the sharders")
+	return nil, common.WrapWithError(customError, common.NewError("transaction_not_found", "Transaction was not found on any of the sharders"))
 }

--- a/core/transaction/entity.go
+++ b/core/transaction/entity.go
@@ -200,7 +200,7 @@ func sendTransactionToURL(url string, txn *Transaction, wg *sync.WaitGroup) ([]b
 	if postResponse.StatusCode >= 200 && postResponse.StatusCode <= 299 {
 		return []byte(postResponse.Body), nil
 	}
-	return nil, common.WrapWithError(err, common.NewError("transaction_send_error", postResponse.Body))
+	return nil, common.WrapError(err, common.NewError("transaction_send_error", postResponse.Body))
 }
 
 func VerifyTransaction(txnHash string, sharders []string) (*Transaction, error) {
@@ -212,39 +212,39 @@ func VerifyTransaction(txnHash string, sharders []string) (*Transaction, error) 
 		url := fmt.Sprintf("%v/%v%v", sharder, TXN_VERIFY_URL, txnHash)
 		req, err := util.NewHTTPGetRequest(url)
 		if err != nil {
-			customError = common.WrapWithError(customError, err)
+			customError = common.WrapError(customError, err)
 			numSharders--
 			continue
 		}
 		response, err := req.Get()
 		if err != nil {
-			customError = common.WrapWithError(customError, err)
+			customError = common.WrapError(customError, err)
 			numSharders--
 			continue
 		} else {
 			if response.StatusCode != 200 {
-				customError = common.WrapWithError(customError, err)
+				customError = common.WrapError(customError, err)
 				continue
 			}
 			contents := response.Body
 			var objmap map[string]json.RawMessage
 			err = json.Unmarshal([]byte(contents), &objmap)
 			if err != nil {
-				customError = common.WrapWithError(customError, err)
+				customError = common.WrapError(customError, err)
 				continue
 			}
 			if _, ok := objmap["txn"]; !ok {
 				if _, ok := objmap["block_hash"]; ok {
 					numSuccess++
 				} else {
-					customError = common.WrapWithMessage(customError, fmt.Sprintf("Sharder does not have the block summary with url: %s, contents: %s", url, contents))
+					customError = common.WrapError(customError, fmt.Sprintf("Sharder does not have the block summary with url: %s, contents: %s", url, contents))
 				}
 				continue
 			}
 			txn := &Transaction{}
 			err = json.Unmarshal(objmap["txn"], txn)
 			if err != nil {
-				customError = common.WrapWithError(customError, err)
+				customError = common.WrapError(customError, err)
 				continue
 			}
 			if len(txn.Signature) > 0 {
@@ -257,7 +257,7 @@ func VerifyTransaction(txnHash string, sharders []string) (*Transaction, error) 
 		if retTxn != nil {
 			return retTxn, nil
 		}
-		return nil, common.WrapWithError(customError, ErrNoTxnDetail)
+		return nil, common.WrapError(customError, ErrNoTxnDetail)
 	}
-	return nil, common.WrapWithError(customError, common.NewError("transaction_not_found", "Transaction was not found on any of the sharders"))
+	return nil, common.WrapError(customError, common.NewError("transaction_not_found", "Transaction was not found on any of the sharders"))
 }

--- a/core/util/merkle_tree.go
+++ b/core/util/merkle_tree.go
@@ -82,7 +82,7 @@ func (mt *MerkleTree) GetTree() []string {
 func (mt *MerkleTree) SetTree(leavesCount int, tree []string) error {
 	size, levels := mt.computeSize(leavesCount)
 	if size != len(tree) {
-		return common.NewErrorMessage(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
+		return common.NewError(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
 	}
 	mt.levels = levels
 	mt.tree = tree

--- a/core/util/merkle_tree.go
+++ b/core/util/merkle_tree.go
@@ -82,7 +82,7 @@ func (mt *MerkleTree) GetTree() []string {
 func (mt *MerkleTree) SetTree(leavesCount int, tree []string) error {
 	size, levels := mt.computeSize(leavesCount)
 	if size != len(tree) {
-		return errors.NewError(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
+		return errors.New(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
 	}
 	mt.levels = levels
 	mt.tree = tree

--- a/core/util/merkle_tree.go
+++ b/core/util/merkle_tree.go
@@ -3,7 +3,7 @@ package util
 import (
 	"fmt"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 )
 
 /*MerkleTree - A data structure that implements MerkleTreeI interface */
@@ -82,7 +82,7 @@ func (mt *MerkleTree) GetTree() []string {
 func (mt *MerkleTree) SetTree(leavesCount int, tree []string) error {
 	size, levels := mt.computeSize(leavesCount)
 	if size != len(tree) {
-		return common.NewError(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
+		return errors.NewError(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
 	}
 	mt.levels = levels
 	mt.tree = tree

--- a/core/util/merkle_tree.go
+++ b/core/util/merkle_tree.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"fmt"
+
+	"github.com/0chain/gosdk/core/common"
 )
 
 /*MerkleTree - A data structure that implements MerkleTreeI interface */
@@ -80,7 +82,7 @@ func (mt *MerkleTree) GetTree() []string {
 func (mt *MerkleTree) SetTree(leavesCount int, tree []string) error {
 	size, levels := mt.computeSize(leavesCount)
 	if size != len(tree) {
-		return fmt.Errorf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree))
+		return common.NewErrorMessage(fmt.Sprintf("Merkle tree with leaves %v should have size %v but only %v is given", leavesCount, size, len(tree)))
 	}
 	mt.levels = levels
 	mt.tree = tree

--- a/core/zcncrypto/bls0chain.go
+++ b/core/zcncrypto/bls0chain.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/herumi/bls-go-binary/bls"
@@ -38,11 +38,11 @@ func (b0 *BLS0ChainScheme) GenerateKeys() (*Wallet, error) {
 	if len(b0.Mnemonic) == 0 {
 		entropy, err := bip39.NewEntropy(256)
 		if err != nil {
-			return nil, common.WrapError(err, "Generating entropy failed")
+			return nil, errors.WrapError(err, "Generating entropy failed")
 		}
 		b0.Mnemonic, err = bip39.NewMnemonic(entropy)
 		if err != nil {
-			return nil, common.WrapError(err, "Generating mnemonic failed")
+			return nil, errors.WrapError(err, "Generating mnemonic failed")
 		}
 	}
 
@@ -77,10 +77,10 @@ func (b0 *BLS0ChainScheme) GenerateKeys() (*Wallet, error) {
 
 func (b0 *BLS0ChainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 	if mnemonic == "" {
-		return nil, common.NewError("recover_keys", "Set mnemonic key failed")
+		return nil, errors.NewError("recover_keys", "Set mnemonic key failed")
 	}
 	if b0.PublicKey != "" || b0.PrivateKey != "" {
-		return nil, common.NewError("recover_keys", "Cannot recover when there are keys")
+		return nil, errors.NewError("recover_keys", "Cannot recover when there are keys")
 	}
 	b0.Mnemonic = mnemonic
 	return b0.GenerateKeys()
@@ -89,10 +89,10 @@ func (b0 *BLS0ChainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 //SetPrivateKey - implement interface
 func (b0 *BLS0ChainScheme) SetPrivateKey(privateKey string) error {
 	if b0.PublicKey != "" {
-		return common.NewError("set_private_key", "cannot set private key when there is a public key")
+		return errors.NewError("set_private_key", "cannot set private key when there is a public key")
 	}
 	if b0.PrivateKey != "" {
-		return common.NewError("set_private_key", "private key already exists")
+		return errors.NewError("set_private_key", "private key already exists")
 	}
 	b0.PrivateKey = privateKey
 	//ToDo: b0.publicKey should be set here?
@@ -102,10 +102,10 @@ func (b0 *BLS0ChainScheme) SetPrivateKey(privateKey string) error {
 //SetPublicKey - implement interface
 func (b0 *BLS0ChainScheme) SetPublicKey(publicKey string) error {
 	if b0.PrivateKey != "" {
-		return common.NewError("set_public_key", "cannot set public key when there is a private key")
+		return errors.NewError("set_public_key", "cannot set public key when there is a private key")
 	}
 	if b0.PublicKey != "" {
-		return common.NewError("set_public_key", "public key already exists")
+		return errors.NewError("set_public_key", "public key already exists")
 	}
 	b0.PublicKey = MiraclToHerumiPK(publicKey)
 	return nil
@@ -147,14 +147,14 @@ func (b0 *BLS0ChainScheme) GetPrivateKey() string {
 func (b0 *BLS0ChainScheme) rawSign(hash string) (*bls.Sign, error) {
 	var sk bls.SecretKey
 	if b0.PrivateKey == "" {
-		return nil, common.NewError("raw_sign", "private key does not exists for signing")
+		return nil, errors.NewError("raw_sign", "private key does not exists for signing")
 	}
 	rawHash, err := hex.DecodeString(hash)
 	if err != nil {
 		return nil, err
 	}
 	if rawHash == nil {
-		return nil, common.NewError("raw_sign", "failed hash while signing")
+		return nil, errors.NewError("raw_sign", "failed hash while signing")
 	}
 	sk.SetByCSPRNG()
 	sk.DeserializeHexStr(b0.PrivateKey)
@@ -174,7 +174,7 @@ func (b0 *BLS0ChainScheme) Sign(hash string) (string, error) {
 //Verify - implement interface
 func (b0 *BLS0ChainScheme) Verify(signature, msg string) (bool, error) {
 	if b0.PublicKey == "" {
-		return false, common.NewError("verify", "public key does not exists for verification")
+		return false, errors.NewError("verify", "public key does not exists for verification")
 	}
 	var sig bls.Sign
 	var pk bls.PublicKey
@@ -187,7 +187,7 @@ func (b0 *BLS0ChainScheme) Verify(signature, msg string) (bool, error) {
 		return false, err
 	}
 	if rawHash == nil {
-		return false, common.NewError("verify", "failed hash while signing")
+		return false, errors.NewError("verify", "failed hash while signing")
 	}
 	pk.DeserializeHexStr(b0.PublicKey)
 	return sig.Verify(&pk, string(rawHash)), nil
@@ -201,7 +201,7 @@ func (b0 *BLS0ChainScheme) Add(signature, msg string) (string, error) {
 	}
 	signature1, err := b0.rawSign(msg)
 	if err != nil {
-		return "", common.WrapError(err, "BLS signing failed")
+		return "", errors.WrapError(err, "BLS signing failed")
 	}
 	sign.Add(signature1)
 	return sign.SerializeToHexStr(), nil
@@ -240,7 +240,7 @@ func (tss *BLS0ChainThresholdScheme) GetID() string {
 // GetPrivateKeyAsByteArray - converts private key into byte array
 func (b0 *BLS0ChainScheme) GetPrivateKeyAsByteArray() ([]byte, error) {
 	if len(b0.PrivateKey) == 0 {
-		return nil, common.NewError("get_private_key_as_byte_array", "cannot convert empty private key to byte array")
+		return nil, errors.NewError("get_private_key_as_byte_array", "cannot convert empty private key to byte array")
 	}
 	privateKeyBytes, err := hex.DecodeString(b0.PrivateKey)
 	if err != nil {
@@ -255,7 +255,7 @@ func BLS0GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]BL
 
 	b0ss, ok := originalKey.(*BLS0ChainScheme)
 	if !ok {
-		return nil, common.NewError("bls0_generate_threshold_key_shares", "Invalid encryption scheme")
+		return nil, errors.NewError("bls0_generate_threshold_key_shares", "Invalid encryption scheme")
 	}
 
 	var b0original bls.SecretKey
@@ -300,7 +300,7 @@ func BLS0GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]BL
 
 func (b0 *BLS0ChainScheme) SplitKeys(numSplits int) (*Wallet, error) {
 	if b0.PrivateKey == "" {
-		return nil, common.NewError("split_keys", "primary private key not found")
+		return nil, errors.NewError("split_keys", "primary private key not found")
 	}
 	var primaryFr bls.Fr
 	var primarySk bls.SecretKey

--- a/core/zcncrypto/bls0chain.go
+++ b/core/zcncrypto/bls0chain.go
@@ -3,8 +3,8 @@ package zcncrypto
 import (
 	"bytes"
 	"encoding/hex"
-	"errors"
 	"fmt"
+	"github.com/0chain/gosdk/core/common"
 	"time"
 
 	"github.com/0chain/gosdk/core/encryption"
@@ -37,11 +37,11 @@ func (b0 *BLS0ChainScheme) GenerateKeys() (*Wallet, error) {
 	if len(b0.Mnemonic) == 0 {
 		entropy, err := bip39.NewEntropy(256)
 		if err != nil {
-			return nil, fmt.Errorf("Generating entropy failed")
+			return nil, common.WrapWithMessage(err, "Generating entropy failed")
 		}
 		b0.Mnemonic, err = bip39.NewMnemonic(entropy)
 		if err != nil {
-			return nil, fmt.Errorf("Generating mnemonic failed")
+			return nil, common.WrapWithMessage(err, "Generating mnemonic failed")
 		}
 	}
 
@@ -76,10 +76,10 @@ func (b0 *BLS0ChainScheme) GenerateKeys() (*Wallet, error) {
 
 func (b0 *BLS0ChainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 	if mnemonic == "" {
-		return nil, fmt.Errorf("Set mnemonic key failed")
+		return nil, common.NewError("recover_keys", "Set mnemonic key failed")
 	}
 	if b0.PublicKey != "" || b0.PrivateKey != "" {
-		return nil, errors.New("Cannot recover when there are keys")
+		return nil, common.NewError("recover_keys", "Cannot recover when there are keys")
 	}
 	b0.Mnemonic = mnemonic
 	return b0.GenerateKeys()
@@ -88,10 +88,10 @@ func (b0 *BLS0ChainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 //SetPrivateKey - implement interface
 func (b0 *BLS0ChainScheme) SetPrivateKey(privateKey string) error {
 	if b0.PublicKey != "" {
-		return errors.New("cannot set private key when there is a public key")
+		return common.NewError("set_private_key", "cannot set private key when there is a public key")
 	}
 	if b0.PrivateKey != "" {
-		return errors.New("private key already exists")
+		return common.NewError("set_private_key", "private key already exists")
 	}
 	b0.PrivateKey = privateKey
 	//ToDo: b0.publicKey should be set here?
@@ -101,10 +101,10 @@ func (b0 *BLS0ChainScheme) SetPrivateKey(privateKey string) error {
 //SetPublicKey - implement interface
 func (b0 *BLS0ChainScheme) SetPublicKey(publicKey string) error {
 	if b0.PrivateKey != "" {
-		return errors.New("cannot set public key when there is a private key")
+		return common.NewError("set_public_key", "cannot set public key when there is a private key")
 	}
 	if b0.PublicKey != "" {
-		return errors.New("public key already exists")
+		return common.NewError("set_public_key", "public key already exists")
 	}
 	b0.PublicKey = MiraclToHerumiPK(publicKey)
 	return nil
@@ -145,14 +145,14 @@ func (b0 *BLS0ChainScheme) GetPrivateKey() string {
 func (b0 *BLS0ChainScheme) rawSign(hash string) (*bls.Sign, error) {
 	var sk bls.SecretKey
 	if b0.PrivateKey == "" {
-		return nil, errors.New("private key does not exists for signing")
+		return nil, common.NewError("raw_sign", "private key does not exists for signing")
 	}
 	rawHash, err := hex.DecodeString(hash)
 	if err != nil {
 		return nil, err
 	}
 	if rawHash == nil {
-		return nil, errors.New("failed hash while signing")
+		return nil, common.NewError("raw_sign", "failed hash while signing")
 	}
 	sk.SetByCSPRNG()
 	sk.DeserializeHexStr(b0.PrivateKey)
@@ -172,7 +172,7 @@ func (b0 *BLS0ChainScheme) Sign(hash string) (string, error) {
 //Verify - implement interface
 func (b0 *BLS0ChainScheme) Verify(signature, msg string) (bool, error) {
 	if b0.PublicKey == "" {
-		return false, errors.New("public key does not exists for verification")
+		return false, common.NewError("verify", "public key does not exists for verification")
 	}
 	var sig bls.Sign
 	var pk bls.PublicKey
@@ -185,7 +185,7 @@ func (b0 *BLS0ChainScheme) Verify(signature, msg string) (bool, error) {
 		return false, err
 	}
 	if rawHash == nil {
-		return false, errors.New("failed hash while signing")
+		return false, common.NewError("verify", "failed hash while signing")
 	}
 	pk.DeserializeHexStr(b0.PublicKey)
 	return sig.Verify(&pk, string(rawHash)), nil
@@ -199,7 +199,7 @@ func (b0 *BLS0ChainScheme) Add(signature, msg string) (string, error) {
 	}
 	signature1, err := b0.rawSign(msg)
 	if err != nil {
-		return "", fmt.Errorf("BLS signing failed - %s", err.Error())
+		return "", common.WrapWithMessage(err, "BLS signing failed")
 	}
 	sign.Add(signature1)
 	return sign.SerializeToHexStr(), nil
@@ -238,7 +238,7 @@ func (tss *BLS0ChainThresholdScheme) GetID() string {
 // GetPrivateKeyAsByteArray - converts private key into byte array
 func (b0 *BLS0ChainScheme) GetPrivateKeyAsByteArray() ([]byte, error) {
 	if len(b0.PrivateKey) == 0 {
-		return nil, errors.New("cannot convert empty private key to byte array")
+		return nil, common.NewError("get_private_key_as_byte_array","cannot convert empty private key to byte array" )
 	}
 	privateKeyBytes, err := hex.DecodeString(b0.PrivateKey)
 	if err != nil {
@@ -253,7 +253,7 @@ func BLS0GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]BL
 
 	b0ss, ok := originalKey.(*BLS0ChainScheme)
 	if !ok {
-		return nil, errors.New("Invalid encryption scheme")
+		return nil, common.NewError("bls0_generate_threshold_key_shares","Invalid encryption scheme" )
 	}
 
 	var b0original bls.SecretKey
@@ -298,7 +298,7 @@ func BLS0GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]BL
 
 func (b0 *BLS0ChainScheme) SplitKeys(numSplits int) (*Wallet, error) {
 	if b0.PrivateKey == "" {
-		return nil, errors.New("primary private key not found")
+		return nil, common.NewError("split_keys", "primary private key not found")
 	}
 	var primaryFr bls.Fr
 	var primarySk bls.SecretKey

--- a/core/zcncrypto/bls0chain.go
+++ b/core/zcncrypto/bls0chain.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"github.com/0chain/gosdk/core/common"
 	"time"
+
+	"github.com/0chain/gosdk/core/common"
 
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/herumi/bls-go-binary/bls"
@@ -37,11 +38,11 @@ func (b0 *BLS0ChainScheme) GenerateKeys() (*Wallet, error) {
 	if len(b0.Mnemonic) == 0 {
 		entropy, err := bip39.NewEntropy(256)
 		if err != nil {
-			return nil, common.WrapWithMessage(err, "Generating entropy failed")
+			return nil, common.WrapError(err, "Generating entropy failed")
 		}
 		b0.Mnemonic, err = bip39.NewMnemonic(entropy)
 		if err != nil {
-			return nil, common.WrapWithMessage(err, "Generating mnemonic failed")
+			return nil, common.WrapError(err, "Generating mnemonic failed")
 		}
 	}
 
@@ -117,6 +118,7 @@ func (b0 *BLS0ChainScheme) SetPublicKey(publicKey string) error {
 //
 // This is an example of the raw public key we expect from MIRACL
 var miraclExamplePK = `0418a02c6bd223ae0dfda1d2f9a3c81726ab436ce5e9d17c531ff0a385a13a0b491bdfed3a85690775ee35c61678957aaba7b1a1899438829f1dc94248d87ed36817f6dfafec19bfa87bf791a4d694f43fec227ae6f5a867490e30328cac05eaff039ac7dfc3364e851ebd2631ea6f1685609fc66d50223cc696cb59ff2fee47ac`
+
 //
 // This is an example of the same MIRACL public key serialized with ToString().
 // pk ([1bdfed3a85690775ee35c61678957aaba7b1a1899438829f1dc94248d87ed368,18a02c6bd223ae0dfda1d2f9a3c81726ab436ce5e9d17c531ff0a385a13a0b49],[039ac7dfc3364e851ebd2631ea6f1685609fc66d50223cc696cb59ff2fee47ac,17f6dfafec19bfa87bf791a4d694f43fec227ae6f5a867490e30328cac05eaff])
@@ -125,9 +127,9 @@ func MiraclToHerumiPK(pk string) string {
 		return pk
 	}
 	n1 := pk[2:66]
-	n2 := pk[66:(66+64)]
-	n3 := pk[(66+64):(66+64+64)]
-	n4 := pk[(66+64+64):(66+64+64+64)]
+	n2 := pk[66:(66 + 64)]
+	n3 := pk[(66 + 64):(66 + 64 + 64)]
+	n4 := pk[(66 + 64 + 64):(66 + 64 + 64 + 64)]
 	var p bls.PublicKey
 	p.SetHexString("1 " + n2 + " " + n1 + " " + n4 + " " + n3)
 	return p.SerializeToHexStr()
@@ -199,7 +201,7 @@ func (b0 *BLS0ChainScheme) Add(signature, msg string) (string, error) {
 	}
 	signature1, err := b0.rawSign(msg)
 	if err != nil {
-		return "", common.WrapWithMessage(err, "BLS signing failed")
+		return "", common.WrapError(err, "BLS signing failed")
 	}
 	sign.Add(signature1)
 	return sign.SerializeToHexStr(), nil
@@ -238,7 +240,7 @@ func (tss *BLS0ChainThresholdScheme) GetID() string {
 // GetPrivateKeyAsByteArray - converts private key into byte array
 func (b0 *BLS0ChainScheme) GetPrivateKeyAsByteArray() ([]byte, error) {
 	if len(b0.PrivateKey) == 0 {
-		return nil, common.NewError("get_private_key_as_byte_array","cannot convert empty private key to byte array" )
+		return nil, common.NewError("get_private_key_as_byte_array", "cannot convert empty private key to byte array")
 	}
 	privateKeyBytes, err := hex.DecodeString(b0.PrivateKey)
 	if err != nil {
@@ -253,7 +255,7 @@ func BLS0GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]BL
 
 	b0ss, ok := originalKey.(*BLS0ChainScheme)
 	if !ok {
-		return nil, common.NewError("bls0_generate_threshold_key_shares","Invalid encryption scheme" )
+		return nil, common.NewError("bls0_generate_threshold_key_shares", "Invalid encryption scheme")
 	}
 
 	var b0original bls.SecretKey

--- a/core/zcncrypto/bls0chain_test.go
+++ b/core/zcncrypto/bls0chain_test.go
@@ -3,9 +3,10 @@ package zcncrypto
 import (
 	"testing"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/encryption"
-	"github.com/stretchr/testify/require"
 	"github.com/herumi/bls-go-binary/bls"
+	"github.com/stretchr/testify/require"
 )
 
 var verifyPublickey = `e8a6cfa7b3076ae7e04764ffdfe341632a136b52953dfafa6926361dd9a466196faecca6f696774bbd64b938ff765dbc837e8766a5e2d8996745b2b94e1beb9e`
@@ -23,7 +24,7 @@ func TestSignatureScheme(t *testing.T) {
 	}
 	w, err := sigScheme.GenerateKeys()
 	if err != nil {
-		t.Fatalf("Generate Key failed %s", err.Error())
+		t.Fatalf("Generate Key failed %s", common.TopLevelError(err))
 	}
 	if w.ClientID == "" || w.ClientKey == "" || len(w.Keys) != 1 || w.Mnemonic == "" {
 		t.Fatalf("Invalid keys generated")
@@ -60,7 +61,7 @@ func BenchmarkBLSSign(b *testing.B) {
 func TestRecoveryKeys(t *testing.T) {
 
 	sigScheme := NewSignatureScheme("bls0chain")
-    TestSignatureScheme(t)
+	TestSignatureScheme(t)
 	w, err := sigScheme.RecoverKeys(blsWallet.Mnemonic)
 	if err != nil {
 		t.Fatalf("set Recover Keys failed")
@@ -81,7 +82,7 @@ func TestCombinedSignAndVerify(t *testing.T) {
 	sig0 := NewSignatureScheme("bls0chain")
 	err := sig0.SetPrivateKey(sk0)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", err.Error())
+		t.Fatalf("Set private key failed - %s", common.TopLevelError(err))
 	}
 	signature, err := sig0.Sign(hash)
 	if err != nil {
@@ -91,7 +92,7 @@ func TestCombinedSignAndVerify(t *testing.T) {
 	sig1 := NewSignatureScheme("bls0chain")
 	err = sig1.SetPrivateKey(sk1)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", err.Error())
+		t.Fatalf("Set private key failed - %s", common.TopLevelError(err))
 	}
 	addSig, err := sig1.Add(signature, hash)
 
@@ -110,7 +111,7 @@ func TestSplitKey(t *testing.T) {
 	sig0 := NewBLS0ChainScheme()
 	err := sig0.SetPrivateKey(primaryKeyStr)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", err.Error())
+		t.Fatalf("Set private key failed - %s", common.TopLevelError(err))
 	}
 	hash := Sha3Sum256(data)
 	signature, err := sig0.Sign(hash)
@@ -120,7 +121,7 @@ func TestSplitKey(t *testing.T) {
 	numSplitKeys := int(2)
 	w, err := sig0.SplitKeys(numSplitKeys)
 	if err != nil {
-		t.Fatalf("Splitkeys key failed - %s", err.Error())
+		t.Fatalf("Splitkeys key failed - %s", common.TopLevelError(err))
 	}
 	sigAggScheme := make([]BLS0ChainScheme, numSplitKeys)
 	for i := 0; i < numSplitKeys; i++ {

--- a/core/zcncrypto/bls0chain_test.go
+++ b/core/zcncrypto/bls0chain_test.go
@@ -3,7 +3,7 @@ package zcncrypto
 import (
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/herumi/bls-go-binary/bls"
 	"github.com/stretchr/testify/require"
@@ -24,7 +24,7 @@ func TestSignatureScheme(t *testing.T) {
 	}
 	w, err := sigScheme.GenerateKeys()
 	if err != nil {
-		t.Fatalf("Generate Key failed %s", common.TopLevelError(err))
+		t.Fatalf("Generate Key failed %s", errors.TopLevelError(err))
 	}
 	if w.ClientID == "" || w.ClientKey == "" || len(w.Keys) != 1 || w.Mnemonic == "" {
 		t.Fatalf("Invalid keys generated")
@@ -82,7 +82,7 @@ func TestCombinedSignAndVerify(t *testing.T) {
 	sig0 := NewSignatureScheme("bls0chain")
 	err := sig0.SetPrivateKey(sk0)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", common.TopLevelError(err))
+		t.Fatalf("Set private key failed - %s", errors.TopLevelError(err))
 	}
 	signature, err := sig0.Sign(hash)
 	if err != nil {
@@ -92,7 +92,7 @@ func TestCombinedSignAndVerify(t *testing.T) {
 	sig1 := NewSignatureScheme("bls0chain")
 	err = sig1.SetPrivateKey(sk1)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", common.TopLevelError(err))
+		t.Fatalf("Set private key failed - %s", errors.TopLevelError(err))
 	}
 	addSig, err := sig1.Add(signature, hash)
 
@@ -111,7 +111,7 @@ func TestSplitKey(t *testing.T) {
 	sig0 := NewBLS0ChainScheme()
 	err := sig0.SetPrivateKey(primaryKeyStr)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", common.TopLevelError(err))
+		t.Fatalf("Set private key failed - %s", errors.TopLevelError(err))
 	}
 	hash := Sha3Sum256(data)
 	signature, err := sig0.Sign(hash)
@@ -121,7 +121,7 @@ func TestSplitKey(t *testing.T) {
 	numSplitKeys := int(2)
 	w, err := sig0.SplitKeys(numSplitKeys)
 	if err != nil {
-		t.Fatalf("Splitkeys key failed - %s", common.TopLevelError(err))
+		t.Fatalf("Splitkeys key failed - %s", errors.TopLevelError(err))
 	}
 	sigAggScheme := make([]BLS0ChainScheme, numSplitKeys)
 	for i := 0; i < numSplitKeys; i++ {

--- a/core/zcncrypto/bls0chain_test.go
+++ b/core/zcncrypto/bls0chain_test.go
@@ -24,7 +24,7 @@ func TestSignatureScheme(t *testing.T) {
 	}
 	w, err := sigScheme.GenerateKeys()
 	if err != nil {
-		t.Fatalf("Generate Key failed %s", errors.TopLevelError(err))
+		t.Fatalf("Generate Key failed %s", errors.Top(err))
 	}
 	if w.ClientID == "" || w.ClientKey == "" || len(w.Keys) != 1 || w.Mnemonic == "" {
 		t.Fatalf("Invalid keys generated")
@@ -82,7 +82,7 @@ func TestCombinedSignAndVerify(t *testing.T) {
 	sig0 := NewSignatureScheme("bls0chain")
 	err := sig0.SetPrivateKey(sk0)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", errors.TopLevelError(err))
+		t.Fatalf("Set private key failed - %s", errors.Top(err))
 	}
 	signature, err := sig0.Sign(hash)
 	if err != nil {
@@ -92,7 +92,7 @@ func TestCombinedSignAndVerify(t *testing.T) {
 	sig1 := NewSignatureScheme("bls0chain")
 	err = sig1.SetPrivateKey(sk1)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", errors.TopLevelError(err))
+		t.Fatalf("Set private key failed - %s", errors.Top(err))
 	}
 	addSig, err := sig1.Add(signature, hash)
 
@@ -111,7 +111,7 @@ func TestSplitKey(t *testing.T) {
 	sig0 := NewBLS0ChainScheme()
 	err := sig0.SetPrivateKey(primaryKeyStr)
 	if err != nil {
-		t.Fatalf("Set private key failed - %s", errors.TopLevelError(err))
+		t.Fatalf("Set private key failed - %s", errors.Top(err))
 	}
 	hash := Sha3Sum256(data)
 	signature, err := sig0.Sign(hash)
@@ -121,7 +121,7 @@ func TestSplitKey(t *testing.T) {
 	numSplitKeys := int(2)
 	w, err := sig0.SplitKeys(numSplitKeys)
 	if err != nil {
-		t.Fatalf("Splitkeys key failed - %s", errors.TopLevelError(err))
+		t.Fatalf("Splitkeys key failed - %s", errors.Top(err))
 	}
 	sigAggScheme := make([]BLS0ChainScheme, numSplitKeys)
 	for i := 0; i < numSplitKeys; i++ {

--- a/core/zcncrypto/ed255190chain.go
+++ b/core/zcncrypto/ed255190chain.go
@@ -3,7 +3,6 @@ package zcncrypto
 import (
 	"bytes"
 	"encoding/hex"
-	"errors"
 	"time"
 
 	"github.com/0chain/gosdk/core/common"
@@ -86,7 +85,7 @@ func (ed *ED255190chainScheme) SetPublicKey(publicKey string) error {
 		return common.NewError("set_public_key", "cannot set public key when there is a private key")
 	}
 	if len(ed.publicKey) > 0 {
-		return errors.New("public key already exists")
+		common.NewError("set_public_key", "public key already exists")
 	}
 	var err error
 	ed.publicKey, err = hex.DecodeString(publicKey)

--- a/core/zcncrypto/ed255190chain.go
+++ b/core/zcncrypto/ed255190chain.go
@@ -42,7 +42,7 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 	r := bytes.NewReader(seed)
 	public, private, err := ed25519.GenerateKey(r)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "Generate keys failed")
+		return nil, common.WrapError(err, "Generate keys failed")
 	}
 	// New Wallet
 	w := &Wallet{}

--- a/core/zcncrypto/ed255190chain.go
+++ b/core/zcncrypto/ed255190chain.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/tyler-smith/go-bip39"
@@ -30,11 +30,11 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 	if len(ed.mnemonic) == 0 {
 		entropy, err := bip39.NewEntropy(256)
 		if err != nil {
-			return nil, common.NewError("generate_keys", "Getting entropy failed")
+			return nil, errors.NewError("generate_keys", "Getting entropy failed")
 		}
 		ed.mnemonic, err = bip39.NewMnemonic(entropy)
 		if err != nil {
-			return nil, common.NewError("generate_keys", "Getting mnemonic failed")
+			return nil, errors.NewError("generate_keys", "Getting mnemonic failed")
 		}
 	}
 
@@ -42,7 +42,7 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 	r := bytes.NewReader(seed)
 	public, private, err := ed25519.GenerateKey(r)
 	if err != nil {
-		return nil, common.WrapError(err, "Generate keys failed")
+		return nil, errors.WrapError(err, "Generate keys failed")
 	}
 	// New Wallet
 	w := &Wallet{}
@@ -59,10 +59,10 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 
 func (ed *ED255190chainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 	if mnemonic == "" {
-		return nil, common.NewError("chain_scheme_recover_keys", "Set mnemonic key failed")
+		return nil, errors.NewError("chain_scheme_recover_keys", "Set mnemonic key failed")
 	}
 	if len(ed.privateKey) > 0 || len(ed.publicKey) > 0 {
-		return nil, common.NewError("chain_scheme_recover_keys", "Cannot recover when there are keys")
+		return nil, errors.NewError("chain_scheme_recover_keys", "Cannot recover when there are keys")
 	}
 	ed.mnemonic = mnemonic
 	return ed.GenerateKeys()
@@ -70,10 +70,10 @@ func (ed *ED255190chainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 
 func (ed *ED255190chainScheme) SetPrivateKey(privateKey string) error {
 	if len(ed.privateKey) > 0 {
-		return common.NewError("set_private_key", "cannot set private key when there is a public key")
+		return errors.NewError("set_private_key", "cannot set private key when there is a public key")
 	}
 	if len(ed.publicKey) > 0 {
-		return common.NewError("set_private_key", "private key already exists")
+		return errors.NewError("set_private_key", "private key already exists")
 	}
 	var err error
 	ed.privateKey, err = hex.DecodeString(privateKey)
@@ -82,10 +82,10 @@ func (ed *ED255190chainScheme) SetPrivateKey(privateKey string) error {
 
 func (ed *ED255190chainScheme) SetPublicKey(publicKey string) error {
 	if len(ed.privateKey) > 0 {
-		return common.NewError("set_public_key", "cannot set public key when there is a private key")
+		return errors.NewError("set_public_key", "cannot set public key when there is a private key")
 	}
 	if len(ed.publicKey) > 0 {
-		common.NewError("set_public_key", "public key already exists")
+		errors.NewError("set_public_key", "public key already exists")
 	}
 	var err error
 	ed.publicKey, err = hex.DecodeString(publicKey)
@@ -94,21 +94,21 @@ func (ed *ED255190chainScheme) SetPublicKey(publicKey string) error {
 
 func (ed *ED255190chainScheme) Sign(hash string) (string, error) {
 	if len(ed.privateKey) == 0 {
-		return "", common.NewError("chain_scheme_sign", "private key does not exists for signing")
+		return "", errors.NewError("chain_scheme_sign", "private key does not exists for signing")
 	}
 	rawHash, err := hex.DecodeString(hash)
 	if err != nil {
 		return "", err
 	}
 	if rawHash == nil {
-		return "", common.NewError("chain_scheme_sign", "Failed hash while signing")
+		return "", errors.NewError("chain_scheme_sign", "Failed hash while signing")
 	}
 	return hex.EncodeToString(ed25519.Sign(ed.privateKey, rawHash)), nil
 }
 
 func (ed *ED255190chainScheme) Verify(signature, msg string) (bool, error) {
 	if len(ed.publicKey) == 0 {
-		return false, common.NewError("chain_scheme_verify", "public key does not exists for verification")
+		return false, errors.NewError("chain_scheme_verify", "public key does not exists for verification")
 	}
 	sign, err := hex.DecodeString(signature)
 	if err != nil {
@@ -122,7 +122,7 @@ func (ed *ED255190chainScheme) Verify(signature, msg string) (bool, error) {
 }
 
 func (ed *ED255190chainScheme) Add(signature, msg string) (string, error) {
-	return "", common.NewError("chain_scheme_add", "Not supported by signature scheme")
+	return "", errors.NewError("chain_scheme_add", "Not supported by signature scheme")
 }
 
 //GetPublicKey - implement interface

--- a/core/zcncrypto/ed255190chain.go
+++ b/core/zcncrypto/ed255190chain.go
@@ -30,11 +30,11 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 	if len(ed.mnemonic) == 0 {
 		entropy, err := bip39.NewEntropy(256)
 		if err != nil {
-			return nil, errors.NewError("generate_keys", "Getting entropy failed")
+			return nil, errors.New("generate_keys", "Getting entropy failed")
 		}
 		ed.mnemonic, err = bip39.NewMnemonic(entropy)
 		if err != nil {
-			return nil, errors.NewError("generate_keys", "Getting mnemonic failed")
+			return nil, errors.New("generate_keys", "Getting mnemonic failed")
 		}
 	}
 
@@ -42,7 +42,7 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 	r := bytes.NewReader(seed)
 	public, private, err := ed25519.GenerateKey(r)
 	if err != nil {
-		return nil, errors.WrapError(err, "Generate keys failed")
+		return nil, errors.Wrap(err, "Generate keys failed")
 	}
 	// New Wallet
 	w := &Wallet{}
@@ -59,10 +59,10 @@ func (ed *ED255190chainScheme) GenerateKeys() (*Wallet, error) {
 
 func (ed *ED255190chainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 	if mnemonic == "" {
-		return nil, errors.NewError("chain_scheme_recover_keys", "Set mnemonic key failed")
+		return nil, errors.New("chain_scheme_recover_keys", "Set mnemonic key failed")
 	}
 	if len(ed.privateKey) > 0 || len(ed.publicKey) > 0 {
-		return nil, errors.NewError("chain_scheme_recover_keys", "Cannot recover when there are keys")
+		return nil, errors.New("chain_scheme_recover_keys", "Cannot recover when there are keys")
 	}
 	ed.mnemonic = mnemonic
 	return ed.GenerateKeys()
@@ -70,10 +70,10 @@ func (ed *ED255190chainScheme) RecoverKeys(mnemonic string) (*Wallet, error) {
 
 func (ed *ED255190chainScheme) SetPrivateKey(privateKey string) error {
 	if len(ed.privateKey) > 0 {
-		return errors.NewError("set_private_key", "cannot set private key when there is a public key")
+		return errors.New("set_private_key", "cannot set private key when there is a public key")
 	}
 	if len(ed.publicKey) > 0 {
-		return errors.NewError("set_private_key", "private key already exists")
+		return errors.New("set_private_key", "private key already exists")
 	}
 	var err error
 	ed.privateKey, err = hex.DecodeString(privateKey)
@@ -82,10 +82,10 @@ func (ed *ED255190chainScheme) SetPrivateKey(privateKey string) error {
 
 func (ed *ED255190chainScheme) SetPublicKey(publicKey string) error {
 	if len(ed.privateKey) > 0 {
-		return errors.NewError("set_public_key", "cannot set public key when there is a private key")
+		return errors.New("set_public_key", "cannot set public key when there is a private key")
 	}
 	if len(ed.publicKey) > 0 {
-		errors.NewError("set_public_key", "public key already exists")
+		errors.New("set_public_key", "public key already exists")
 	}
 	var err error
 	ed.publicKey, err = hex.DecodeString(publicKey)
@@ -94,21 +94,21 @@ func (ed *ED255190chainScheme) SetPublicKey(publicKey string) error {
 
 func (ed *ED255190chainScheme) Sign(hash string) (string, error) {
 	if len(ed.privateKey) == 0 {
-		return "", errors.NewError("chain_scheme_sign", "private key does not exists for signing")
+		return "", errors.New("chain_scheme_sign", "private key does not exists for signing")
 	}
 	rawHash, err := hex.DecodeString(hash)
 	if err != nil {
 		return "", err
 	}
 	if rawHash == nil {
-		return "", errors.NewError("chain_scheme_sign", "Failed hash while signing")
+		return "", errors.New("chain_scheme_sign", "Failed hash while signing")
 	}
 	return hex.EncodeToString(ed25519.Sign(ed.privateKey, rawHash)), nil
 }
 
 func (ed *ED255190chainScheme) Verify(signature, msg string) (bool, error) {
 	if len(ed.publicKey) == 0 {
-		return false, errors.NewError("chain_scheme_verify", "public key does not exists for verification")
+		return false, errors.New("chain_scheme_verify", "public key does not exists for verification")
 	}
 	sign, err := hex.DecodeString(signature)
 	if err != nil {
@@ -122,7 +122,7 @@ func (ed *ED255190chainScheme) Verify(signature, msg string) (bool, error) {
 }
 
 func (ed *ED255190chainScheme) Add(signature, msg string) (string, error) {
-	return "", errors.NewError("chain_scheme_add", "Not supported by signature scheme")
+	return "", errors.New("chain_scheme_add", "Not supported by signature scheme")
 }
 
 //GetPublicKey - implement interface

--- a/core/zcncrypto/ed25519_test.go
+++ b/core/zcncrypto/ed25519_test.go
@@ -23,7 +23,7 @@ func TestEd25519GenerateKeys(t *testing.T) {
 	}
 	w, err := sigScheme.GenerateKeys()
 	if err != nil {
-		t.Fatalf("Generate keys failed %s", errors.TopLevelError(err))
+		t.Fatalf("Generate keys failed %s", errors.Top(err))
 	}
 	if w.ClientID == "" || w.ClientKey == "" || len(w.Keys) != 1 || w.Mnemonic == "" {
 		t.Fatalf("Invalid keys generated")

--- a/core/zcncrypto/ed25519_test.go
+++ b/core/zcncrypto/ed25519_test.go
@@ -3,6 +3,8 @@ package zcncrypto
 import (
 	"encoding/hex"
 	"testing"
+
+	"github.com/0chain/gosdk/core/common"
 )
 
 var edverifyPublickey = `b987071c14695caf340ea11560f5a3cb76ad1e709803a8b339826ab3964e470a`
@@ -21,7 +23,7 @@ func TestEd25519GenerateKeys(t *testing.T) {
 	}
 	w, err := sigScheme.GenerateKeys()
 	if err != nil {
-		t.Fatalf("Generate keys failed %s", err.Error())
+		t.Fatalf("Generate keys failed %s", common.TopLevelError(err))
 	}
 	if w.ClientID == "" || w.ClientKey == "" || len(w.Keys) != 1 || w.Mnemonic == "" {
 		t.Fatalf("Invalid keys generated")

--- a/core/zcncrypto/ed25519_test.go
+++ b/core/zcncrypto/ed25519_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 )
 
 var edverifyPublickey = `b987071c14695caf340ea11560f5a3cb76ad1e709803a8b339826ab3964e470a`
@@ -23,7 +23,7 @@ func TestEd25519GenerateKeys(t *testing.T) {
 	}
 	w, err := sigScheme.GenerateKeys()
 	if err != nil {
-		t.Fatalf("Generate keys failed %s", common.TopLevelError(err))
+		t.Fatalf("Generate keys failed %s", errors.TopLevelError(err))
 	}
 	if w.ClientID == "" || w.ClientKey == "" || len(w.Keys) != 1 || w.Mnemonic == "" {
 		t.Fatalf("Invalid keys generated")

--- a/core/zcncrypto/zcncrypto.go
+++ b/core/zcncrypto/zcncrypto.go
@@ -70,7 +70,7 @@ func NewSignatureScheme(sigScheme string) SignatureScheme {
 func (w *Wallet) Marshal() (string, error) {
 	ws, err := json.Marshal(w)
 	if err != nil {
-		return "", errors.NewError("wallet_marshal", "Invalid Wallet")
+		return "", errors.New("wallet_marshal", "Invalid Wallet")
 	}
 	return string(ws), nil
 }

--- a/core/zcncrypto/zcncrypto.go
+++ b/core/zcncrypto/zcncrypto.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/0chain/gosdk/core/common"
+
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/tyler-smith/go-bip39"
 )
@@ -46,6 +48,7 @@ type SignatureScheme interface {
 	// Combine signature for schemes BLS
 	Add(signature, msg string) (string, error)
 }
+
 // SplitSignatureScheme splits the primary key into number of parts.
 type SplitSignatureScheme interface {
 	SignatureScheme
@@ -62,14 +65,13 @@ func NewSignatureScheme(sigScheme string) SignatureScheme {
 	default:
 		panic(fmt.Sprintf("unknown signature scheme: %v", sigScheme))
 	}
-	return nil
 }
 
 // Marshal returns json string
 func (w *Wallet) Marshal() (string, error) {
 	ws, err := json.Marshal(w)
 	if err != nil {
-		return "", fmt.Errorf("Invalid Wallet")
+		return "", common.NewError("wallet_marshal", "Invalid Wallet")
 	}
 	return string(ws), nil
 }

--- a/core/zcncrypto/zcncrypto.go
+++ b/core/zcncrypto/zcncrypto.go
@@ -4,8 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/0chain/gosdk/core/common"
-
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/tyler-smith/go-bip39"
 )
@@ -71,7 +70,7 @@ func NewSignatureScheme(sigScheme string) SignatureScheme {
 func (w *Wallet) Marshal() (string, error) {
 	ws, err := json.Marshal(w)
 	if err != nil {
-		return "", common.NewError("wallet_marshal", "Invalid Wallet")
+		return "", errors.NewError("wallet_marshal", "Invalid Wallet")
 	}
 	return string(ws), nil
 }

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/zboxcore/allocationchange/attributes.go
+++ b/zboxcore/allocationchange/attributes.go
@@ -39,7 +39,7 @@ func (ac *AttributesChange) ProcessChange(root *fileref.Ref) (err error) {
 		if found {
 			treelevel++
 		} else {
-			return errors.NewError("attributes_change_process",
+			return errors.New("attributes_change_process",
 				"Invalid reference path from the blobber")
 		}
 	}
@@ -57,7 +57,7 @@ func (ac *AttributesChange) ProcessChange(root *fileref.Ref) (err error) {
 	}
 
 	if idx < 0 || file == nil {
-		return errors.NewError("attributes_change_process",
+		return errors.New("attributes_change_process",
 			"File, to update attributes for, not found in blobber")
 	}
 

--- a/zboxcore/allocationchange/attributes.go
+++ b/zboxcore/allocationchange/attributes.go
@@ -3,7 +3,7 @@ package allocationchange
 import (
 	"path/filepath"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 )
 
@@ -39,7 +39,7 @@ func (ac *AttributesChange) ProcessChange(root *fileref.Ref) (err error) {
 		if found {
 			treelevel++
 		} else {
-			return common.NewError("attributes_change_process",
+			return errors.NewError("attributes_change_process",
 				"Invalid reference path from the blobber")
 		}
 	}
@@ -57,7 +57,7 @@ func (ac *AttributesChange) ProcessChange(root *fileref.Ref) (err error) {
 	}
 
 	if idx < 0 || file == nil {
-		return common.NewError("attributes_change_process",
+		return errors.NewError("attributes_change_process",
 			"File, to update attributes for, not found in blobber")
 	}
 

--- a/zboxcore/allocationchange/copyobject.go
+++ b/zboxcore/allocationchange/copyobject.go
@@ -33,7 +33,7 @@ func (ch *CopyFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.New("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	var foundRef fileref.RefEntity
@@ -49,7 +49,7 @@ func (ch *CopyFileChange) ProcessChange(rootRef *fileref.Ref) error {
 	}
 
 	if foundRef == nil {
-		return errors.NewError("file_not_found", "Object to copy not found in blobber")
+		return errors.New("file_not_found", "Object to copy not found in blobber")
 	}
 
 	var affectedRef *fileref.Ref

--- a/zboxcore/allocationchange/copyobject.go
+++ b/zboxcore/allocationchange/copyobject.go
@@ -3,7 +3,7 @@ package allocationchange
 import (
 	"path/filepath"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	"github.com/0chain/gosdk/zboxcore/zboxutil"
 )
@@ -33,7 +33,7 @@ func (ch *CopyFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return common.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	var foundRef fileref.RefEntity
@@ -49,7 +49,7 @@ func (ch *CopyFileChange) ProcessChange(rootRef *fileref.Ref) error {
 	}
 
 	if foundRef == nil {
-		return common.NewError("file_not_found", "Object to copy not found in blobber")
+		return errors.NewError("file_not_found", "Object to copy not found in blobber")
 	}
 
 	var affectedRef *fileref.Ref

--- a/zboxcore/allocationchange/deletefile.go
+++ b/zboxcore/allocationchange/deletefile.go
@@ -32,7 +32,7 @@ func (ch *DeleteFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.New("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	idx := -1
@@ -43,7 +43,7 @@ func (ch *DeleteFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		}
 	}
 	if idx < 0 {
-		return errors.NewError("file_not_found", "File to delete not found in blobber")
+		return errors.New("file_not_found", "File to delete not found in blobber")
 	}
 	//dirRef.Children = append(dirRef.Children[:idx], dirRef.Children[idx+1:]...)
 	dirRef.RemoveChild(idx)

--- a/zboxcore/allocationchange/deletefile.go
+++ b/zboxcore/allocationchange/deletefile.go
@@ -3,7 +3,7 @@ package allocationchange
 import (
 	"path/filepath"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 )
 
@@ -32,7 +32,7 @@ func (ch *DeleteFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return common.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	idx := -1
@@ -43,7 +43,7 @@ func (ch *DeleteFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		}
 	}
 	if idx < 0 {
-		return common.NewError("file_not_found", "File to delete not found in blobber")
+		return errors.NewError("file_not_found", "File to delete not found in blobber")
 	}
 	//dirRef.Children = append(dirRef.Children[:idx], dirRef.Children[idx+1:]...)
 	dirRef.RemoveChild(idx)

--- a/zboxcore/allocationchange/renameobject.go
+++ b/zboxcore/allocationchange/renameobject.go
@@ -33,7 +33,7 @@ func (ch *RenameFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.New("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	idx := -1
@@ -44,7 +44,7 @@ func (ch *RenameFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		}
 	}
 	if idx < 0 {
-		return errors.NewError("file_not_found", "Object to rename not found in blobber")
+		return errors.New("file_not_found", "Object to rename not found in blobber")
 	}
 	dirRef.Children[idx] = ch.ObjectTree
 	// Logger.Info("Old name: " + dirRef.Children[idx].GetName())

--- a/zboxcore/allocationchange/renameobject.go
+++ b/zboxcore/allocationchange/renameobject.go
@@ -3,7 +3,7 @@ package allocationchange
 import (
 	"path/filepath"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	"github.com/0chain/gosdk/zboxcore/zboxutil"
 )
@@ -33,7 +33,7 @@ func (ch *RenameFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return common.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	idx := -1
@@ -44,7 +44,7 @@ func (ch *RenameFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		}
 	}
 	if idx < 0 {
-		return common.NewError("file_not_found", "Object to rename not found in blobber")
+		return errors.NewError("file_not_found", "Object to rename not found in blobber")
 	}
 	dirRef.Children[idx] = ch.ObjectTree
 	// Logger.Info("Old name: " + dirRef.Children[idx].GetName())

--- a/zboxcore/allocationchange/updatefile.go
+++ b/zboxcore/allocationchange/updatefile.go
@@ -32,7 +32,7 @@ func (ch *UpdateFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.New("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	idx := -1
@@ -44,7 +44,7 @@ func (ch *UpdateFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		}
 	}
 	if idx < 0 || ch.OldFile == nil {
-		return errors.NewError("file_not_found", "File to update not found in blobber")
+		return errors.New("file_not_found", "File to update not found in blobber")
 	}
 	dirRef.Children[idx] = ch.NewFile
 	rootRef.CalculateHash()

--- a/zboxcore/allocationchange/updatefile.go
+++ b/zboxcore/allocationchange/updatefile.go
@@ -3,7 +3,7 @@ package allocationchange
 import (
 	"path/filepath"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 )
 
@@ -32,7 +32,7 @@ func (ch *UpdateFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		if found {
 			treelevel++
 		} else {
-			return common.NewError("invalid_reference_path", "Invalid reference path from the blobber")
+			return errors.NewError("invalid_reference_path", "Invalid reference path from the blobber")
 		}
 	}
 	idx := -1
@@ -44,7 +44,7 @@ func (ch *UpdateFileChange) ProcessChange(rootRef *fileref.Ref) error {
 		}
 	}
 	if idx < 0 || ch.OldFile == nil {
-		return common.NewError("file_not_found", "File to update not found in blobber")
+		return errors.NewError("file_not_found", "File to update not found in blobber")
 	}
 	dirRef.Children[idx] = ch.NewFile
 	rootRef.CalculateHash()

--- a/zboxcore/encoder/erasurecode.go
+++ b/zboxcore/encoder/erasurecode.go
@@ -3,7 +3,7 @@ package encoder
 import (
 	"bufio"
 	"bytes"
-	"errors"
+	"github.com/0chain/gosdk/core/common"
 
 	. "github.com/0chain/gosdk/zboxcore/logger"
 
@@ -54,7 +54,7 @@ func (e *StreamEncoder) Encode(in []byte) ([][]byte, error) {
 func (e *StreamEncoder) Decode(in [][]byte, shardSize int) ([]byte, error) {
 	// Verify the input
 	if (len(in) < e.iDataShards+e.iParityShards) || (shardSize <= 0) {
-		return []byte{}, errors.New("Invalid input length")
+		return []byte{}, common.NewErrorMessage("Invalid input length")
 	}
 
 	err := e.erasureCode.Reconstruct(in)

--- a/zboxcore/encoder/erasurecode.go
+++ b/zboxcore/encoder/erasurecode.go
@@ -54,7 +54,7 @@ func (e *StreamEncoder) Encode(in []byte) ([][]byte, error) {
 func (e *StreamEncoder) Decode(in [][]byte, shardSize int) ([]byte, error) {
 	// Verify the input
 	if (len(in) < e.iDataShards+e.iParityShards) || (shardSize <= 0) {
-		return []byte{}, errors.NewError("Invalid input length")
+		return []byte{}, errors.New("Invalid input length")
 	}
 
 	err := e.erasureCode.Reconstruct(in)

--- a/zboxcore/encoder/erasurecode.go
+++ b/zboxcore/encoder/erasurecode.go
@@ -54,7 +54,7 @@ func (e *StreamEncoder) Encode(in []byte) ([][]byte, error) {
 func (e *StreamEncoder) Decode(in [][]byte, shardSize int) ([]byte, error) {
 	// Verify the input
 	if (len(in) < e.iDataShards+e.iParityShards) || (shardSize <= 0) {
-		return []byte{}, common.NewErrorMessage("Invalid input length")
+		return []byte{}, common.NewError("Invalid input length")
 	}
 
 	err := e.erasureCode.Reconstruct(in)

--- a/zboxcore/encoder/erasurecode.go
+++ b/zboxcore/encoder/erasurecode.go
@@ -3,8 +3,8 @@ package encoder
 import (
 	"bufio"
 	"bytes"
-	"github.com/0chain/gosdk/core/common"
 
+	"github.com/0chain/gosdk/core/common/errors"
 	. "github.com/0chain/gosdk/zboxcore/logger"
 
 	"github.com/klauspost/reedsolomon"
@@ -54,7 +54,7 @@ func (e *StreamEncoder) Encode(in []byte) ([][]byte, error) {
 func (e *StreamEncoder) Decode(in [][]byte, shardSize int) ([]byte, error) {
 	// Verify the input
 	if (len(in) < e.iDataShards+e.iParityShards) || (shardSize <= 0) {
-		return []byte{}, common.NewError("Invalid input length")
+		return []byte{}, errors.NewError("Invalid input length")
 	}
 
 	err := e.erasureCode.Reconstruct(in)

--- a/zboxcore/encryption/pre.go
+++ b/zboxcore/encryption/pre.go
@@ -9,8 +9,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 
+	"github.com/0chain/gosdk/core/common"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 )
@@ -342,7 +342,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	alp := pre.hash6(g, C.TagA, pre.PrivateKey) // alp = H6(tagA,skA)
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, alp)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, fmt.Errorf("Invalid Ciphertext in decrypt, C4 != H5")
+		return nil, common.NewErrorMessage("Invalid Ciphertext in decrypt, C4 != H5")
 	}
 	Ht := pre.hash1(pre.SuiteObj, pre.Tag, pre.PrivateKey) // Ht  = H1(tagA,skA)
 	T := g.Point().Sub(C.EncryptedKey, Ht)                 // T   = C1 - Ht
@@ -351,7 +351,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, C.MessageChecksum) { // Check if C3 = H3(m,T)
-			return nil, fmt.Errorf("Invalid Ciphertext in decrypt, C3 != H3")
+			return nil, common.NewErrorMessage("Invalid Ciphertext in decrypt, C3 != H3")
 		} else {
 			//fmt.Println("First level ciphertext decrypted successfully")
 			return recmsg, nil
@@ -393,7 +393,7 @@ func (pre *PREEncryptionScheme) reEncrypt(encMsg *EncryptedMessage, reGenKey str
 
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, rk.R3)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, fmt.Errorf("Invalid Ciphertext in reEncrypt, C4 != H5")
+		return nil, common.NewErrorMessage("Invalid Ciphertext in reEncrypt, C4 != H5")
 	}
 	t := s.Scalar().Pick(s.RandomStream()) // Pick a random integer t
 	reEncMsg.D5 = s.Point().Mul(t, nil)    // D5    = tP
@@ -425,7 +425,7 @@ func (pre *PREEncryptionScheme) reDecrypt(D *reEncryptedMessage) ([]byte, error)
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, D.D3) { // Check if D3 = H3(m,T)
-			return nil, fmt.Errorf("Invalid Ciphertext in reDecrypt, D3 != H3")
+			return nil, common.NewErrorMessage("Invalid Ciphertext in reDecrypt, D3 != H3")
 		} else {
 			return recmsg, nil
 		}

--- a/zboxcore/encryption/pre.go
+++ b/zboxcore/encryption/pre.go
@@ -342,7 +342,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	alp := pre.hash6(g, C.TagA, pre.PrivateKey) // alp = H6(tagA,skA)
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, alp)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, errors.NewError("Invalid Ciphertext in decrypt, C4 != H5")
+		return nil, errors.New("Invalid Ciphertext in decrypt, C4 != H5")
 	}
 	Ht := pre.hash1(pre.SuiteObj, pre.Tag, pre.PrivateKey) // Ht  = H1(tagA,skA)
 	T := g.Point().Sub(C.EncryptedKey, Ht)                 // T   = C1 - Ht
@@ -351,7 +351,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, C.MessageChecksum) { // Check if C3 = H3(m,T)
-			return nil, errors.NewError("Invalid Ciphertext in decrypt, C3 != H3")
+			return nil, errors.New("Invalid Ciphertext in decrypt, C3 != H3")
 		} else {
 			//fmt.Println("First level ciphertext decrypted successfully")
 			return recmsg, nil
@@ -393,7 +393,7 @@ func (pre *PREEncryptionScheme) reEncrypt(encMsg *EncryptedMessage, reGenKey str
 
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, rk.R3)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, errors.NewError("Invalid Ciphertext in reEncrypt, C4 != H5")
+		return nil, errors.New("Invalid Ciphertext in reEncrypt, C4 != H5")
 	}
 	t := s.Scalar().Pick(s.RandomStream()) // Pick a random integer t
 	reEncMsg.D5 = s.Point().Mul(t, nil)    // D5    = tP
@@ -425,7 +425,7 @@ func (pre *PREEncryptionScheme) reDecrypt(D *reEncryptedMessage) ([]byte, error)
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, D.D3) { // Check if D3 = H3(m,T)
-			return nil, errors.NewError("Invalid Ciphertext in reDecrypt, D3 != H3")
+			return nil, errors.New("Invalid Ciphertext in reDecrypt, D3 != H3")
 		} else {
 			return recmsg, nil
 		}

--- a/zboxcore/encryption/pre.go
+++ b/zboxcore/encryption/pre.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 )
@@ -342,7 +342,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	alp := pre.hash6(g, C.TagA, pre.PrivateKey) // alp = H6(tagA,skA)
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, alp)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, common.NewError("Invalid Ciphertext in decrypt, C4 != H5")
+		return nil, errors.NewError("Invalid Ciphertext in decrypt, C4 != H5")
 	}
 	Ht := pre.hash1(pre.SuiteObj, pre.Tag, pre.PrivateKey) // Ht  = H1(tagA,skA)
 	T := g.Point().Sub(C.EncryptedKey, Ht)                 // T   = C1 - Ht
@@ -351,7 +351,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, C.MessageChecksum) { // Check if C3 = H3(m,T)
-			return nil, common.NewError("Invalid Ciphertext in decrypt, C3 != H3")
+			return nil, errors.NewError("Invalid Ciphertext in decrypt, C3 != H3")
 		} else {
 			//fmt.Println("First level ciphertext decrypted successfully")
 			return recmsg, nil
@@ -393,7 +393,7 @@ func (pre *PREEncryptionScheme) reEncrypt(encMsg *EncryptedMessage, reGenKey str
 
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, rk.R3)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, common.NewError("Invalid Ciphertext in reEncrypt, C4 != H5")
+		return nil, errors.NewError("Invalid Ciphertext in reEncrypt, C4 != H5")
 	}
 	t := s.Scalar().Pick(s.RandomStream()) // Pick a random integer t
 	reEncMsg.D5 = s.Point().Mul(t, nil)    // D5    = tP
@@ -425,7 +425,7 @@ func (pre *PREEncryptionScheme) reDecrypt(D *reEncryptedMessage) ([]byte, error)
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, D.D3) { // Check if D3 = H3(m,T)
-			return nil, common.NewError("Invalid Ciphertext in reDecrypt, D3 != H3")
+			return nil, errors.NewError("Invalid Ciphertext in reDecrypt, D3 != H3")
 		} else {
 			return recmsg, nil
 		}

--- a/zboxcore/encryption/pre.go
+++ b/zboxcore/encryption/pre.go
@@ -342,7 +342,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	alp := pre.hash6(g, C.TagA, pre.PrivateKey) // alp = H6(tagA,skA)
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, alp)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, common.NewErrorMessage("Invalid Ciphertext in decrypt, C4 != H5")
+		return nil, common.NewError("Invalid Ciphertext in decrypt, C4 != H5")
 	}
 	Ht := pre.hash1(pre.SuiteObj, pre.Tag, pre.PrivateKey) // Ht  = H1(tagA,skA)
 	T := g.Point().Sub(C.EncryptedKey, Ht)                 // T   = C1 - Ht
@@ -351,7 +351,7 @@ func (pre *PREEncryptionScheme) decrypt(encMsg *EncryptedMessage) ([]byte, error
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, C.MessageChecksum) { // Check if C3 = H3(m,T)
-			return nil, common.NewErrorMessage("Invalid Ciphertext in decrypt, C3 != H3")
+			return nil, common.NewError("Invalid Ciphertext in decrypt, C3 != H3")
 		} else {
 			//fmt.Println("First level ciphertext decrypted successfully")
 			return recmsg, nil
@@ -393,7 +393,7 @@ func (pre *PREEncryptionScheme) reEncrypt(encMsg *EncryptedMessage, reGenKey str
 
 	chk1 := pre.hash5(g, C.EncryptedKey, C.EncryptedData, C.MessageChecksum, rk.R3)
 	if !bytes.Equal(chk1, C.OverallChecksum) { // Check if C4 = H5(C1,C2,C3,alp)
-		return nil, common.NewErrorMessage("Invalid Ciphertext in reEncrypt, C4 != H5")
+		return nil, common.NewError("Invalid Ciphertext in reEncrypt, C4 != H5")
 	}
 	t := s.Scalar().Pick(s.RandomStream()) // Pick a random integer t
 	reEncMsg.D5 = s.Point().Mul(t, nil)    // D5    = tP
@@ -425,7 +425,7 @@ func (pre *PREEncryptionScheme) reDecrypt(D *reEncryptedMessage) ([]byte, error)
 	if err2 == nil {
 		chk2 := pre.hash3(g, recmsg, T)
 		if !bytes.Equal(chk2, D.D3) { // Check if D3 = H3(m,T)
-			return nil, common.NewErrorMessage("Invalid Ciphertext in reDecrypt, D3 != H3")
+			return nil, common.NewError("Invalid Ciphertext in reDecrypt, D3 != H3")
 		} else {
 			return recmsg, nil
 		}

--- a/zboxcore/fileref/fileref.go
+++ b/zboxcore/fileref/fileref.go
@@ -2,7 +2,6 @@ package fileref
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -51,7 +50,7 @@ func (a *Attributes) IsZero() bool {
 // Validate the Attributes.
 func (a *Attributes) Validate() (err error) {
 	if err = a.WhoPaysForReads.Validate(); err != nil {
-		return fmt.Errorf("invalid who_pays_for_reads field: %v", err)
+		return common.WrapWithMessage(err, "invalid who_pays_for_reads field")
 	}
 	return
 }

--- a/zboxcore/fileref/fileref.go
+++ b/zboxcore/fileref/fileref.go
@@ -50,7 +50,7 @@ func (a *Attributes) IsZero() bool {
 // Validate the Attributes.
 func (a *Attributes) Validate() (err error) {
 	if err = a.WhoPaysForReads.Validate(); err != nil {
-		return common.WrapWithMessage(err, "invalid who_pays_for_reads field")
+		return common.WrapError(err, "invalid who_pays_for_reads field")
 	}
 	return
 }

--- a/zboxcore/fileref/fileref.go
+++ b/zboxcore/fileref/fileref.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 )
 
@@ -50,7 +51,7 @@ func (a *Attributes) IsZero() bool {
 // Validate the Attributes.
 func (a *Attributes) Validate() (err error) {
 	if err = a.WhoPaysForReads.Validate(); err != nil {
-		return common.WrapError(err, "invalid who_pays_for_reads field")
+		return errors.WrapError(err, "invalid who_pays_for_reads field")
 	}
 	return
 }

--- a/zboxcore/fileref/fileref.go
+++ b/zboxcore/fileref/fileref.go
@@ -51,7 +51,7 @@ func (a *Attributes) IsZero() bool {
 // Validate the Attributes.
 func (a *Attributes) Validate() (err error) {
 	if err = a.WhoPaysForReads.Validate(); err != nil {
-		return errors.WrapError(err, "invalid who_pays_for_reads field")
+		return errors.Wrap(err, "invalid who_pays_for_reads field")
 	}
 	return
 }

--- a/zboxcore/fileref/list.go
+++ b/zboxcore/fileref/list.go
@@ -1,7 +1,7 @@
 package fileref
 
 import (
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -36,7 +36,7 @@ func (lr *ListResult) GetDirTree(allocationID string) (*Ref, error) {
 		}
 		return rootRef, nil
 	}
-	return nil, common.NewError("invalid_list_path", "Invalid list path. list was not for a directory")
+	return nil, errors.NewError("invalid_list_path", "Invalid list path. list was not for a directory")
 }
 
 func (lr *ListResult) populateChildren(ref *Ref) error {

--- a/zboxcore/fileref/list.go
+++ b/zboxcore/fileref/list.go
@@ -36,7 +36,7 @@ func (lr *ListResult) GetDirTree(allocationID string) (*Ref, error) {
 		}
 		return rootRef, nil
 	}
-	return nil, errors.NewError("invalid_list_path", "Invalid list path. list was not for a directory")
+	return nil, errors.New("invalid_list_path", "Invalid list path. list was not for a directory")
 }
 
 func (lr *ListResult) populateChildren(ref *Ref) error {

--- a/zboxcore/fileref/refpath.go
+++ b/zboxcore/fileref/refpath.go
@@ -60,7 +60,7 @@ func (rp *ReferencePath) GetDirTree(allocationID string) (*Ref, error) {
 		}
 		return rootRef, nil
 	}
-	return nil, errors.NewError("invalid_ref_path", "Invalid reference path. root was not a directory type")
+	return nil, errors.New("invalid_ref_path", "Invalid reference path. root was not a directory type")
 }
 
 func (rp *ReferencePath) populateChildren(ref *Ref) error {

--- a/zboxcore/fileref/refpath.go
+++ b/zboxcore/fileref/refpath.go
@@ -1,7 +1,7 @@
 package fileref
 
 import (
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -60,7 +60,7 @@ func (rp *ReferencePath) GetDirTree(allocationID string) (*Ref, error) {
 		}
 		return rootRef, nil
 	}
-	return nil, common.NewError("invalid_ref_path", "Invalid reference path. root was not a directory type")
+	return nil, errors.NewError("invalid_ref_path", "Invalid reference path. root was not a directory type")
 }
 
 func (rp *ReferencePath) populateChildren(ref *Ref) error {

--- a/zboxcore/marker/writemarker.go
+++ b/zboxcore/marker/writemarker.go
@@ -3,7 +3,7 @@ package marker
 import (
 	"fmt"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/zboxcore/client"
 )
@@ -40,10 +40,10 @@ func (wm *WriteMarker) VerifySignature(clientPublicKey string) error {
 	signatureHash := encryption.Hash(hashData)
 	sigOK, err := client.VerifySignature(wm.Signature, signatureHash)
 	if err != nil {
-		return common.NewError("write_marker_validation_failed", "Error during verifying signature. "+err.Error())
+		return errors.NewError("write_marker_validation_failed", "Error during verifying signature. "+err.Error())
 	}
 	if !sigOK {
-		return common.NewError("write_marker_validation_failed", "Write marker signature is not valid")
+		return errors.NewError("write_marker_validation_failed", "Write marker signature is not valid")
 	}
 	return nil
 }

--- a/zboxcore/marker/writemarker.go
+++ b/zboxcore/marker/writemarker.go
@@ -40,10 +40,10 @@ func (wm *WriteMarker) VerifySignature(clientPublicKey string) error {
 	signatureHash := encryption.Hash(hashData)
 	sigOK, err := client.VerifySignature(wm.Signature, signatureHash)
 	if err != nil {
-		return errors.NewError("write_marker_validation_failed", "Error during verifying signature. "+err.Error())
+		return errors.New("write_marker_validation_failed", "Error during verifying signature. "+err.Error())
 	}
 	if !sigOK {
-		return errors.NewError("write_marker_validation_failed", "Write marker signature is not valid")
+		return errors.New("write_marker_validation_failed", "Write marker signature is not valid")
 	}
 	return nil
 }

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -27,8 +27,8 @@ import (
 )
 
 var (
-	noBLOBBERS     = errors.NewError("No Blobbers set in this allocation")
-	notInitialized = errors.NewError("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
+	noBLOBBERS     = errors.New("No Blobbers set in this allocation")
+	notInitialized = errors.New("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
 )
 
 const (
@@ -327,7 +327,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 
 	fileInfo, err := GetFileInfo(localpath)
 	if err != nil {
-		return errors.WrapError(err, "Local file error")
+		return errors.Wrap(err, "Local file error")
 	}
 	thumbnailSize := int64(0)
 	if len(thumbnailpath) > 0 {
@@ -344,7 +344,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	remotepath = zboxutil.RemoteClean(remotepath)
 	isabs := zboxutil.IsRemoteAbs(remotepath)
 	if !isabs {
-		return errors.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.New("invalid_path", "Path should be valid and absolute")
 	}
 	remotepath = zboxutil.GetFullRemotePath(localpath, remotepath)
 
@@ -385,7 +385,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		}
 
 		if !repairRequired {
-			return errors.NewError("Repair not required")
+			return errors.New("Repair not required")
 		}
 
 		file, _ := ioutil.ReadFile(localpath)
@@ -393,7 +393,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		hash.Write(file)
 		contentHash := hex.EncodeToString(hash.Sum(nil))
 		if contentHash != fileRef.ActualFileHash {
-			return errors.NewError("Content hash doesn't match")
+			return errors.New("Content hash doesn't match")
 		}
 
 		uploadReq.filemeta.Hash = fileRef.ActualFileHash
@@ -402,7 +402,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	}
 
 	if !uploadReq.IsFullConsensusSupported() {
-		return errors.NewError(fmt.Sprintf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported()))
+		return errors.New(fmt.Sprintf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported()))
 	}
 
 	go func() {
@@ -429,7 +429,7 @@ func (a *Allocation) RepairRequired(remotepath string) (zboxutil.Uint128, bool, 
 	listReq.remotefilepath = remotepath
 	found, fileRef, _ := listReq.getFileConsensusFromBlobbers()
 	if fileRef == nil {
-		return found, false, fileRef, errors.NewError("File not found for the given remotepath")
+		return found, false, fileRef, errors.New("File not found for the given remotepath")
 	}
 
 	uploadMask := zboxutil.NewUint128(1).Lsh(uint64(len(a.Blobbers))).Sub64(1)
@@ -457,13 +457,13 @@ func (a *Allocation) downloadFile(localPath string, remotePath string, contentMo
 	}
 	if stat, err := os.Stat(localPath); err == nil {
 		if !stat.IsDir() {
-			return errors.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
+			return errors.New(fmt.Sprintf("Local path is not a directory '%s'", localPath))
 		}
 		localPath = strings.TrimRight(localPath, "/")
 		_, rFile := filepath.Split(remotePath)
 		localPath = fmt.Sprintf("%s/%s", localPath, rFile)
 		if _, err := os.Stat(localPath); err == nil {
-			return errors.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
+			return errors.New(fmt.Sprintf("Local file already exists '%s'", localPath))
 		}
 	}
 	lPath, _ := filepath.Split(localPath)
@@ -510,15 +510,15 @@ func (a *Allocation) ListDirFromAuthTicket(authTicket string, lookupHash string)
 	}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return nil, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return nil, errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return nil, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return nil, errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	if len(at.FilePathHash) == 0 || len(lookupHash) == 0 {
-		return nil, errors.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.New("invalid_path", "Invalid path for the list")
 	}
 
 	listReq := &ListRequest{}
@@ -534,7 +534,7 @@ func (a *Allocation) ListDirFromAuthTicket(authTicket string, lookupHash string)
 	if ref != nil {
 		return ref, nil
 	}
-	return nil, errors.NewError("list_request_failed", "Failed to get list response from the blobbers")
+	return nil, errors.New("list_request_failed", "Failed to get list response from the blobbers")
 }
 
 func (a *Allocation) ListDir(path string) (*ListResult, error) {
@@ -548,12 +548,12 @@ func (a *Allocation) listDir(path string, consensusThresh, fullconsensus float32
 		return nil, notInitialized
 	}
 	if len(path) == 0 {
-		return nil, errors.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.New("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return nil, errors.NewError("invalid_path", "Path should be valid and absolute")
+		return nil, errors.New("invalid_path", "Path should be valid and absolute")
 	}
 	listReq := &ListRequest{}
 	listReq.allocationID = a.ID
@@ -567,7 +567,7 @@ func (a *Allocation) listDir(path string, consensusThresh, fullconsensus float32
 	if ref != nil {
 		return ref, nil
 	}
-	return nil, errors.NewError("list_request_failed", "Failed to get list response from the blobbers")
+	return nil, errors.New("list_request_failed", "Failed to get list response from the blobbers")
 }
 
 func (a *Allocation) GetFileMeta(path string) (*ConsolidatedFileMeta, error) {
@@ -601,7 +601,7 @@ func (a *Allocation) GetFileMeta(path string) (*ConsolidatedFileMeta, error) {
 		result.ActualNumBlocks = ref.NumBlocks
 		return result, nil
 	}
-	return nil, errors.NewError("file_meta_error", "Error getting the file meta data from blobbers")
+	return nil, errors.New("file_meta_error", "Error getting the file meta data from blobbers")
 }
 
 func (a *Allocation) GetFileMetaFromAuthTicket(authTicket string, lookupHash string) (*ConsolidatedFileMeta, error) {
@@ -612,15 +612,15 @@ func (a *Allocation) GetFileMetaFromAuthTicket(authTicket string, lookupHash str
 	result := &ConsolidatedFileMeta{}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return nil, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return nil, errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return nil, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return nil, errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	if len(at.FilePathHash) == 0 || len(lookupHash) == 0 {
-		return nil, errors.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.New("invalid_path", "Invalid path for the list")
 	}
 
 	listReq := &ListRequest{}
@@ -646,7 +646,7 @@ func (a *Allocation) GetFileMetaFromAuthTicket(authTicket string, lookupHash str
 		result.ActualNumBlocks = ref.NumBlocks
 		return result, nil
 	}
-	return nil, errors.NewError("file_meta_error", "Error getting the file meta data from blobbers")
+	return nil, errors.New("file_meta_error", "Error getting the file meta data from blobbers")
 }
 
 func (a *Allocation) GetFileStats(path string) (map[string]*FileStats, error) {
@@ -654,12 +654,12 @@ func (a *Allocation) GetFileStats(path string) (map[string]*FileStats, error) {
 		return nil, notInitialized
 	}
 	if len(path) == 0 {
-		return nil, errors.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.New("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return nil, errors.NewError("invalid_path", "Path should be valid and absolute")
+		return nil, errors.New("invalid_path", "Path should be valid and absolute")
 	}
 	listReq := &ListRequest{}
 	listReq.allocationID = a.ID
@@ -673,7 +673,7 @@ func (a *Allocation) GetFileStats(path string) (map[string]*FileStats, error) {
 	if ref != nil {
 		return ref, nil
 	}
-	return nil, errors.NewError("file_stats_request_failed", "Failed to get file stats response from the blobbers")
+	return nil, errors.New("file_stats_request_failed", "Failed to get file stats response from the blobbers")
 }
 
 func (a *Allocation) DeleteFile(path string) error {
@@ -688,12 +688,12 @@ func (a *Allocation) deleteFile(path string, threshConsensus, fullConsensus floa
 	}
 
 	if len(path) == 0 {
-		return errors.NewError("invalid_path", "Invalid path for the list")
+		return errors.New("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return errors.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.New("invalid_path", "Path should be valid and absolute")
 	}
 
 	req := &DeleteRequest{}
@@ -717,12 +717,12 @@ func (a *Allocation) RenameObject(path string, destName string) error {
 	}
 
 	if len(path) == 0 {
-		return errors.NewError("invalid_path", "Invalid path for the list")
+		return errors.New("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return errors.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.New("invalid_path", "Path should be valid and absolute")
 	}
 
 	req := &RenameRequest{}
@@ -748,13 +748,13 @@ func (a *Allocation) UpdateObjectAttributes(path string,
 	}
 
 	if len(path) == 0 {
-		return errors.NewError("update_attrs", "Invalid path for the list")
+		return errors.New("update_attrs", "Invalid path for the list")
 	}
 
 	path = zboxutil.RemoteClean(path)
 	var isabs = zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return errors.NewError("update_attrs",
+		return errors.New("update_attrs",
 			"Path should be valid and absolute")
 	}
 
@@ -794,12 +794,12 @@ func (a *Allocation) CopyObject(path string, destPath string) error {
 	}
 
 	if len(path) == 0 || len(destPath) == 0 {
-		return errors.NewError("invalid_path", "Invalid path for copy")
+		return errors.New("invalid_path", "Invalid path for copy")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return errors.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.New("invalid_path", "Path should be valid and absolute")
 	}
 
 	req := &CopyRequest{}
@@ -826,12 +826,12 @@ func (a *Allocation) GetAuthTicket(path string, filename string, referenceType s
 		return "", notInitialized
 	}
 	if len(path) == 0 {
-		return "", errors.NewError("invalid_path", "Invalid path for the list")
+		return "", errors.New("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return "", errors.NewError("invalid_path", "Path should be valid and absolute")
+		return "", errors.New("invalid_path", "Path should be valid and absolute")
 	}
 
 	shareReq := &ShareRequest{}
@@ -866,7 +866,7 @@ func (a *Allocation) CancelUpload(localpath string) error {
 		uploadReq.isUploadCanceled = true
 		return nil
 	}
-	return errors.NewError("local_path_not_found", "Invalid path. No upload in progress for the path "+localpath)
+	return errors.New("local_path_not_found", "Invalid path. No upload in progress for the path "+localpath)
 }
 
 func (a *Allocation) CancelDownload(remotepath string) error {
@@ -874,7 +874,7 @@ func (a *Allocation) CancelDownload(remotepath string) error {
 		downloadReq.isDownloadCanceled = true
 		return nil
 	}
-	return errors.NewError("remote_path_not_found", "Invalid path. No download in progress for the path "+remotepath)
+	return errors.New("remote_path_not_found", "Invalid path. No download in progress for the path "+remotepath)
 }
 
 func (a *Allocation) DownloadThumbnailFromAuthTicket(localPath string,
@@ -915,22 +915,22 @@ func (a *Allocation) downloadFromAuthTicket(localPath string, authTicket string,
 	}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	if stat, err := os.Stat(localPath); err == nil {
 		if !stat.IsDir() {
-			return errors.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
+			return errors.New(fmt.Sprintf("Local path is not a directory '%s'", localPath))
 		}
 		localPath = strings.TrimRight(localPath, "/")
 		_, rFile := filepath.Split(remoteFilename)
 		localPath = fmt.Sprintf("%s/%s", localPath, rFile)
 		if _, err := os.Stat(localPath); err == nil {
-			return errors.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
+			return errors.New(fmt.Sprintf("Local file already exists '%s'", localPath))
 		}
 	}
 	if len(a.Blobbers) <= 1 {
@@ -1040,7 +1040,7 @@ func (a *Allocation) CancelRepair() error {
 		a.repairRequestInProgress.isRepairCanceled = true
 		return nil
 	}
-	return errors.NewError("invalid_cancel_repair_request", "No repair in progress for the allocation")
+	return errors.New("invalid_cancel_repair_request", "No repair in progress for the allocation")
 }
 
 type CommitFolderData struct {
@@ -1098,7 +1098,7 @@ func (a *Allocation) CommitFolderChange(operation, preValue, currValue string) (
 		return "", err
 	}
 	if t == nil {
-		err = errors.NewError("transaction_validation_failed", "Failed to get the transaction confirmation")
+		err = errors.New("transaction_validation_failed", "Failed to get the transaction confirmation")
 		return "", err
 	}
 
@@ -1131,7 +1131,7 @@ func (a *Allocation) AddCollaborator(filePath, collaboratorID string) error {
 	if req.UpdateCollaboratorToBlobbers() {
 		return nil
 	}
-	return errors.NewError("add_collaborator_failed", "Failed to add collaborator on all blobbers.")
+	return errors.New("add_collaborator_failed", "Failed to add collaborator on all blobbers.")
 }
 
 func (a *Allocation) RemoveCollaborator(filePath, collaboratorID string) error {
@@ -1148,7 +1148,7 @@ func (a *Allocation) RemoveCollaborator(filePath, collaboratorID string) error {
 	if req.RemoveCollaboratorFromBlobbers() {
 		return nil
 	}
-	return errors.NewError("remove_collaborator_failed", "Failed to remove collaborator on all blobbers.")
+	return errors.New("remove_collaborator_failed", "Failed to remove collaborator on all blobbers.")
 }
 
 func (a *Allocation) GetMaxWriteRead() (maxW float64, maxR float64, err error) {

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/transaction"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -26,8 +27,8 @@ import (
 )
 
 var (
-	noBLOBBERS     = common.NewError("No Blobbers set in this allocation")
-	notInitialized = common.NewError("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
+	noBLOBBERS     = errors.NewError("No Blobbers set in this allocation")
+	notInitialized = errors.NewError("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
 )
 
 const (
@@ -326,7 +327,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 
 	fileInfo, err := GetFileInfo(localpath)
 	if err != nil {
-		return common.WrapError(err, "Local file error")
+		return errors.WrapError(err, "Local file error")
 	}
 	thumbnailSize := int64(0)
 	if len(thumbnailpath) > 0 {
@@ -343,7 +344,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	remotepath = zboxutil.RemoteClean(remotepath)
 	isabs := zboxutil.IsRemoteAbs(remotepath)
 	if !isabs {
-		return common.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 	remotepath = zboxutil.GetFullRemotePath(localpath, remotepath)
 
@@ -384,7 +385,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		}
 
 		if !repairRequired {
-			return common.NewError("Repair not required")
+			return errors.NewError("Repair not required")
 		}
 
 		file, _ := ioutil.ReadFile(localpath)
@@ -392,7 +393,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		hash.Write(file)
 		contentHash := hex.EncodeToString(hash.Sum(nil))
 		if contentHash != fileRef.ActualFileHash {
-			return common.NewError("Content hash doesn't match")
+			return errors.NewError("Content hash doesn't match")
 		}
 
 		uploadReq.filemeta.Hash = fileRef.ActualFileHash
@@ -401,7 +402,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	}
 
 	if !uploadReq.IsFullConsensusSupported() {
-		return common.NewError(fmt.Sprintf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported()))
+		return errors.NewError(fmt.Sprintf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported()))
 	}
 
 	go func() {
@@ -428,7 +429,7 @@ func (a *Allocation) RepairRequired(remotepath string) (zboxutil.Uint128, bool, 
 	listReq.remotefilepath = remotepath
 	found, fileRef, _ := listReq.getFileConsensusFromBlobbers()
 	if fileRef == nil {
-		return found, false, fileRef, common.NewError("File not found for the given remotepath")
+		return found, false, fileRef, errors.NewError("File not found for the given remotepath")
 	}
 
 	uploadMask := zboxutil.NewUint128(1).Lsh(uint64(len(a.Blobbers))).Sub64(1)
@@ -456,13 +457,13 @@ func (a *Allocation) downloadFile(localPath string, remotePath string, contentMo
 	}
 	if stat, err := os.Stat(localPath); err == nil {
 		if !stat.IsDir() {
-			return common.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
+			return errors.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
 		}
 		localPath = strings.TrimRight(localPath, "/")
 		_, rFile := filepath.Split(remotePath)
 		localPath = fmt.Sprintf("%s/%s", localPath, rFile)
 		if _, err := os.Stat(localPath); err == nil {
-			return common.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
+			return errors.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
 		}
 	}
 	lPath, _ := filepath.Split(localPath)
@@ -509,15 +510,15 @@ func (a *Allocation) ListDirFromAuthTicket(authTicket string, lookupHash string)
 	}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return nil, common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return nil, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return nil, common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return nil, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	if len(at.FilePathHash) == 0 || len(lookupHash) == 0 {
-		return nil, common.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.NewError("invalid_path", "Invalid path for the list")
 	}
 
 	listReq := &ListRequest{}
@@ -533,7 +534,7 @@ func (a *Allocation) ListDirFromAuthTicket(authTicket string, lookupHash string)
 	if ref != nil {
 		return ref, nil
 	}
-	return nil, common.NewError("list_request_failed", "Failed to get list response from the blobbers")
+	return nil, errors.NewError("list_request_failed", "Failed to get list response from the blobbers")
 }
 
 func (a *Allocation) ListDir(path string) (*ListResult, error) {
@@ -547,12 +548,12 @@ func (a *Allocation) listDir(path string, consensusThresh, fullconsensus float32
 		return nil, notInitialized
 	}
 	if len(path) == 0 {
-		return nil, common.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.NewError("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return nil, common.NewError("invalid_path", "Path should be valid and absolute")
+		return nil, errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 	listReq := &ListRequest{}
 	listReq.allocationID = a.ID
@@ -566,7 +567,7 @@ func (a *Allocation) listDir(path string, consensusThresh, fullconsensus float32
 	if ref != nil {
 		return ref, nil
 	}
-	return nil, common.NewError("list_request_failed", "Failed to get list response from the blobbers")
+	return nil, errors.NewError("list_request_failed", "Failed to get list response from the blobbers")
 }
 
 func (a *Allocation) GetFileMeta(path string) (*ConsolidatedFileMeta, error) {
@@ -600,7 +601,7 @@ func (a *Allocation) GetFileMeta(path string) (*ConsolidatedFileMeta, error) {
 		result.ActualNumBlocks = ref.NumBlocks
 		return result, nil
 	}
-	return nil, common.NewError("file_meta_error", "Error getting the file meta data from blobbers")
+	return nil, errors.NewError("file_meta_error", "Error getting the file meta data from blobbers")
 }
 
 func (a *Allocation) GetFileMetaFromAuthTicket(authTicket string, lookupHash string) (*ConsolidatedFileMeta, error) {
@@ -611,15 +612,15 @@ func (a *Allocation) GetFileMetaFromAuthTicket(authTicket string, lookupHash str
 	result := &ConsolidatedFileMeta{}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return nil, common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return nil, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return nil, common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return nil, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	if len(at.FilePathHash) == 0 || len(lookupHash) == 0 {
-		return nil, common.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.NewError("invalid_path", "Invalid path for the list")
 	}
 
 	listReq := &ListRequest{}
@@ -645,7 +646,7 @@ func (a *Allocation) GetFileMetaFromAuthTicket(authTicket string, lookupHash str
 		result.ActualNumBlocks = ref.NumBlocks
 		return result, nil
 	}
-	return nil, common.NewError("file_meta_error", "Error getting the file meta data from blobbers")
+	return nil, errors.NewError("file_meta_error", "Error getting the file meta data from blobbers")
 }
 
 func (a *Allocation) GetFileStats(path string) (map[string]*FileStats, error) {
@@ -653,12 +654,12 @@ func (a *Allocation) GetFileStats(path string) (map[string]*FileStats, error) {
 		return nil, notInitialized
 	}
 	if len(path) == 0 {
-		return nil, common.NewError("invalid_path", "Invalid path for the list")
+		return nil, errors.NewError("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return nil, common.NewError("invalid_path", "Path should be valid and absolute")
+		return nil, errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 	listReq := &ListRequest{}
 	listReq.allocationID = a.ID
@@ -672,7 +673,7 @@ func (a *Allocation) GetFileStats(path string) (map[string]*FileStats, error) {
 	if ref != nil {
 		return ref, nil
 	}
-	return nil, common.NewError("file_stats_request_failed", "Failed to get file stats response from the blobbers")
+	return nil, errors.NewError("file_stats_request_failed", "Failed to get file stats response from the blobbers")
 }
 
 func (a *Allocation) DeleteFile(path string) error {
@@ -687,12 +688,12 @@ func (a *Allocation) deleteFile(path string, threshConsensus, fullConsensus floa
 	}
 
 	if len(path) == 0 {
-		return common.NewError("invalid_path", "Invalid path for the list")
+		return errors.NewError("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return common.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 
 	req := &DeleteRequest{}
@@ -716,12 +717,12 @@ func (a *Allocation) RenameObject(path string, destName string) error {
 	}
 
 	if len(path) == 0 {
-		return common.NewError("invalid_path", "Invalid path for the list")
+		return errors.NewError("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return common.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 
 	req := &RenameRequest{}
@@ -747,13 +748,13 @@ func (a *Allocation) UpdateObjectAttributes(path string,
 	}
 
 	if len(path) == 0 {
-		return common.NewError("update_attrs", "Invalid path for the list")
+		return errors.NewError("update_attrs", "Invalid path for the list")
 	}
 
 	path = zboxutil.RemoteClean(path)
 	var isabs = zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return common.NewError("update_attrs",
+		return errors.NewError("update_attrs",
 			"Path should be valid and absolute")
 	}
 
@@ -793,12 +794,12 @@ func (a *Allocation) CopyObject(path string, destPath string) error {
 	}
 
 	if len(path) == 0 || len(destPath) == 0 {
-		return common.NewError("invalid_path", "Invalid path for copy")
+		return errors.NewError("invalid_path", "Invalid path for copy")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return common.NewError("invalid_path", "Path should be valid and absolute")
+		return errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 
 	req := &CopyRequest{}
@@ -825,12 +826,12 @@ func (a *Allocation) GetAuthTicket(path string, filename string, referenceType s
 		return "", notInitialized
 	}
 	if len(path) == 0 {
-		return "", common.NewError("invalid_path", "Invalid path for the list")
+		return "", errors.NewError("invalid_path", "Invalid path for the list")
 	}
 	path = zboxutil.RemoteClean(path)
 	isabs := zboxutil.IsRemoteAbs(path)
 	if !isabs {
-		return "", common.NewError("invalid_path", "Path should be valid and absolute")
+		return "", errors.NewError("invalid_path", "Path should be valid and absolute")
 	}
 
 	shareReq := &ShareRequest{}
@@ -865,7 +866,7 @@ func (a *Allocation) CancelUpload(localpath string) error {
 		uploadReq.isUploadCanceled = true
 		return nil
 	}
-	return common.NewError("local_path_not_found", "Invalid path. No upload in progress for the path "+localpath)
+	return errors.NewError("local_path_not_found", "Invalid path. No upload in progress for the path "+localpath)
 }
 
 func (a *Allocation) CancelDownload(remotepath string) error {
@@ -873,7 +874,7 @@ func (a *Allocation) CancelDownload(remotepath string) error {
 		downloadReq.isDownloadCanceled = true
 		return nil
 	}
-	return common.NewError("remote_path_not_found", "Invalid path. No download in progress for the path "+remotepath)
+	return errors.NewError("remote_path_not_found", "Invalid path. No download in progress for the path "+remotepath)
 }
 
 func (a *Allocation) DownloadThumbnailFromAuthTicket(localPath string,
@@ -914,22 +915,22 @@ func (a *Allocation) downloadFromAuthTicket(localPath string, authTicket string,
 	}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	if stat, err := os.Stat(localPath); err == nil {
 		if !stat.IsDir() {
-			return common.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
+			return errors.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
 		}
 		localPath = strings.TrimRight(localPath, "/")
 		_, rFile := filepath.Split(remoteFilename)
 		localPath = fmt.Sprintf("%s/%s", localPath, rFile)
 		if _, err := os.Stat(localPath); err == nil {
-			return common.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
+			return errors.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
 		}
 	}
 	if len(a.Blobbers) <= 1 {
@@ -1039,7 +1040,7 @@ func (a *Allocation) CancelRepair() error {
 		a.repairRequestInProgress.isRepairCanceled = true
 		return nil
 	}
-	return common.NewError("invalid_cancel_repair_request", "No repair in progress for the allocation")
+	return errors.NewError("invalid_cancel_repair_request", "No repair in progress for the allocation")
 }
 
 type CommitFolderData struct {
@@ -1097,7 +1098,7 @@ func (a *Allocation) CommitFolderChange(operation, preValue, currValue string) (
 		return "", err
 	}
 	if t == nil {
-		err = common.NewError("transaction_validation_failed", "Failed to get the transaction confirmation")
+		err = errors.NewError("transaction_validation_failed", "Failed to get the transaction confirmation")
 		return "", err
 	}
 
@@ -1130,7 +1131,7 @@ func (a *Allocation) AddCollaborator(filePath, collaboratorID string) error {
 	if req.UpdateCollaboratorToBlobbers() {
 		return nil
 	}
-	return common.NewError("add_collaborator_failed", "Failed to add collaborator on all blobbers.")
+	return errors.NewError("add_collaborator_failed", "Failed to add collaborator on all blobbers.")
 }
 
 func (a *Allocation) RemoveCollaborator(filePath, collaboratorID string) error {
@@ -1147,7 +1148,7 @@ func (a *Allocation) RemoveCollaborator(filePath, collaboratorID string) error {
 	if req.RemoveCollaboratorFromBlobbers() {
 		return nil
 	}
-	return common.NewError("remove_collaborator_failed", "Failed to remove collaborator on all blobbers.")
+	return errors.NewError("remove_collaborator_failed", "Failed to remove collaborator on all blobbers.")
 }
 
 func (a *Allocation) GetMaxWriteRead() (maxW float64, maxR float64, err error) {

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	noBLOBBERS     = common.NewError("no_blobbers", "No Blobbers set in this allocation")
+	noBLOBBERS     = common.NewErrorMessage("No Blobbers set in this allocation")
 	notInitialized = common.NewError("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
 )
 

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	noBLOBBERS     = common.NewErrorMessage("No Blobbers set in this allocation")
+	noBLOBBERS     = common.NewError("No Blobbers set in this allocation")
 	notInitialized = common.NewError("sdk_not_initialized", "Please call InitStorageSDK Init and use GetAllocation to get the allocation object")
 )
 
@@ -326,7 +326,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 
 	fileInfo, err := GetFileInfo(localpath)
 	if err != nil {
-		return common.WrapWithMessage(err, "Local file error")
+		return common.WrapError(err, "Local file error")
 	}
 	thumbnailSize := int64(0)
 	if len(thumbnailpath) > 0 {
@@ -384,7 +384,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		}
 
 		if !repairRequired {
-			return common.NewErrorMessage("Repair not required")
+			return common.NewError("Repair not required")
 		}
 
 		file, _ := ioutil.ReadFile(localpath)
@@ -392,7 +392,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 		hash.Write(file)
 		contentHash := hex.EncodeToString(hash.Sum(nil))
 		if contentHash != fileRef.ActualFileHash {
-			return common.NewErrorMessage("Content hash doesn't match")
+			return common.NewError("Content hash doesn't match")
 		}
 
 		uploadReq.filemeta.Hash = fileRef.ActualFileHash
@@ -401,7 +401,7 @@ func (a *Allocation) uploadOrUpdateFile(localpath string, remotepath string,
 	}
 
 	if !uploadReq.IsFullConsensusSupported() {
-		return common.NewErrorMessage(fmt.Sprintf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported()))
+		return common.NewError(fmt.Sprintf("allocation requires [%v] blobbers, which is greater than the maximum permitted number of [%v]. reduce number of data or parity shards and try again", uploadReq.fullconsensus, uploadReq.GetMaxBlobbersSupported()))
 	}
 
 	go func() {
@@ -428,7 +428,7 @@ func (a *Allocation) RepairRequired(remotepath string) (zboxutil.Uint128, bool, 
 	listReq.remotefilepath = remotepath
 	found, fileRef, _ := listReq.getFileConsensusFromBlobbers()
 	if fileRef == nil {
-		return found, false, fileRef, common.NewErrorMessage("File not found for the given remotepath")
+		return found, false, fileRef, common.NewError("File not found for the given remotepath")
 	}
 
 	uploadMask := zboxutil.NewUint128(1).Lsh(uint64(len(a.Blobbers))).Sub64(1)
@@ -456,13 +456,13 @@ func (a *Allocation) downloadFile(localPath string, remotePath string, contentMo
 	}
 	if stat, err := os.Stat(localPath); err == nil {
 		if !stat.IsDir() {
-			return common.NewErrorMessage(fmt.Sprintf("Local path is not a directory '%s'", localPath))
+			return common.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
 		}
 		localPath = strings.TrimRight(localPath, "/")
 		_, rFile := filepath.Split(remotePath)
 		localPath = fmt.Sprintf("%s/%s", localPath, rFile)
 		if _, err := os.Stat(localPath); err == nil {
-			return common.NewErrorMessage(fmt.Sprintf("Local file already exists '%s'", localPath))
+			return common.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
 		}
 	}
 	lPath, _ := filepath.Split(localPath)
@@ -923,13 +923,13 @@ func (a *Allocation) downloadFromAuthTicket(localPath string, authTicket string,
 	}
 	if stat, err := os.Stat(localPath); err == nil {
 		if !stat.IsDir() {
-			return common.NewErrorMessage(fmt.Sprintf("Local path is not a directory '%s'", localPath))
+			return common.NewError(fmt.Sprintf("Local path is not a directory '%s'", localPath))
 		}
 		localPath = strings.TrimRight(localPath, "/")
 		_, rFile := filepath.Split(remoteFilename)
 		localPath = fmt.Sprintf("%s/%s", localPath, rFile)
 		if _, err := os.Stat(localPath); err == nil {
-			return common.NewErrorMessage(fmt.Sprintf("Local file already exists '%s'", localPath))
+			return common.NewError(fmt.Sprintf("Local file already exists '%s'", localPath))
 		}
 	}
 	if len(a.Blobbers) <= 1 {

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -197,8 +197,8 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanImplicitLimit128(t *testing.T)
 	var expectedErr = "allocation requires [129] blobbers, which is greater than the maximum permitted number of [128]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
-	} else if errors.TopLevelError(err) != expectedErr {
-		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, errors.TopLevelError(err))
+	} else if errors.Top(err) != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, errors.Top(err))
 	}
 }
 
@@ -221,8 +221,8 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanExplicitLimit(t *testing.T) {
 	var expectedErr = "allocation requires [11] blobbers, which is greater than the maximum permitted number of [10]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
-	} else if errors.TopLevelError(err) != expectedErr {
-		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, errors.TopLevelError(err))
+	} else if errors.Top(err) != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, errors.Top(err))
 	}
 }
 
@@ -612,7 +612,7 @@ func TestAllocation_RepairFile(t *testing.T) {
 			err := a.RepairFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.status)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error %v", err)
@@ -975,7 +975,7 @@ func TestAllocation_uploadOrUpdateFile(t *testing.T) {
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
 
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error %v", err)
@@ -1125,7 +1125,7 @@ func TestAllocation_RepairRequired(t *testing.T) {
 			}
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			expected := &fileref.FileRef{
@@ -1385,7 +1385,7 @@ func TestAllocation_downloadFile(t *testing.T) {
 			err := a.downloadFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.contentMode, tt.parameters.startBlock, tt.parameters.endBlock, tt.parameters.numBlocks, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error: %v", err)
@@ -1527,7 +1527,7 @@ func TestAllocation_deleteFile(t *testing.T) {
 			err := a.DeleteFile(tt.parameters.path)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1677,7 +1677,7 @@ func TestAllocation_UpdateObjectAttributes(t *testing.T) {
 			err := a.UpdateObjectAttributes(tt.parameters.path, tt.parameters.attrs)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1770,7 +1770,7 @@ func TestAllocation_MoveObject(t *testing.T) {
 			err := a.MoveObject(tt.parameters.path, tt.parameters.destPath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1875,7 +1875,7 @@ func TestAllocation_CopyObject(t *testing.T) {
 			err := a.CopyObject(tt.parameters.path, tt.parameters.destPath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1980,7 +1980,7 @@ func TestAllocation_RenameObject(t *testing.T) {
 			err := a.RenameObject(tt.parameters.path, tt.parameters.destName)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2068,7 +2068,7 @@ func TestAllocation_AddCollaborator(t *testing.T) {
 			err := a.AddCollaborator(tt.parameters.filePath, tt.parameters.collaboratorID)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2156,7 +2156,7 @@ func TestAllocation_RemoveCollaborator(t *testing.T) {
 			err := a.RemoveCollaborator(tt.parameters.filePath, tt.parameters.collaboratorID)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2255,7 +2255,7 @@ func TestAllocation_GetFileMeta(t *testing.T) {
 			got, err := a.GetFileMeta(tt.parameters.path)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2394,7 +2394,7 @@ func TestAllocation_GetAuthTicket(t *testing.T) {
 			at, err := a.GetAuthTicket(tt.parameters.path, tt.parameters.filename, tt.parameters.referenceType, tt.parameters.refereeClientID, tt.parameters.refereeEncryptionPublicKey)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2445,7 +2445,7 @@ func TestAllocation_CancelUpload(t *testing.T) {
 			err := a.CancelUpload(tt.parameters.localpath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2621,7 +2621,7 @@ func TestAllocation_CommitFolderChange(t *testing.T) {
 			_, err := a.CommitFolderChange(tt.parameters.operation, tt.parameters.preValue, tt.parameters.currValue)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2765,7 +2765,7 @@ func TestAllocation_ListDirFromAuthTicket(t *testing.T) {
 			got, err := a.ListDirFromAuthTicket(tt.parameters.authTicket, tt.parameters.lookupHash)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2941,7 +2941,7 @@ func TestAllocation_downloadFromAuthTicket(t *testing.T) {
 			err := a.downloadFromAuthTicket(tt.parameters.localPath, tt.parameters.authTicket, tt.parameters.lookupHash, tt.parameters.startBlock, tt.parameters.endBlock, tt.parameters.numBlocks, tt.parameters.remoteFilename, tt.parameters.contentMode, tt.parameters.rxPay, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3061,7 +3061,7 @@ func TestAllocation_listDir(t *testing.T) {
 			got, err := a.listDir(tt.parameters.path, tt.parameters.consensusThresh, tt.parameters.fullConsensus)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3187,7 +3187,7 @@ func TestAllocation_GetFileMetaFromAuthTicket(t *testing.T) {
 			got, err := a.GetFileMetaFromAuthTicket(tt.parameters.authTicket, tt.parameters.lookupHash)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3432,7 +3432,7 @@ func TestAllocation_CommitMetaTransaction(t *testing.T) {
 			}
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3520,7 +3520,7 @@ func TestAllocation_StartRepair(t *testing.T) {
 			err := a.StartRepair(tt.parameters.localPath, tt.parameters.pathToRepair, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3561,7 +3561,7 @@ func TestAllocation_CancelRepair(t *testing.T) {
 			err := a.CancelRepair()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/transaction"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/core/zcncrypto"
@@ -197,8 +197,8 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanImplicitLimit128(t *testing.T)
 	var expectedErr = "allocation requires [129] blobbers, which is greater than the maximum permitted number of [128]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
-	} else if common.TopLevelError(err) != expectedErr {
-		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, common.TopLevelError(err))
+	} else if errors.TopLevelError(err) != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, errors.TopLevelError(err))
 	}
 }
 
@@ -221,8 +221,8 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanExplicitLimit(t *testing.T) {
 	var expectedErr = "allocation requires [11] blobbers, which is greater than the maximum permitted number of [10]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
-	} else if common.TopLevelError(err) != expectedErr {
-		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, common.TopLevelError(err))
+	} else if errors.TopLevelError(err) != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, errors.TopLevelError(err))
 	}
 }
 
@@ -612,7 +612,7 @@ func TestAllocation_RepairFile(t *testing.T) {
 			err := a.RepairFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.status)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error %v", err)
@@ -974,11 +974,8 @@ func TestAllocation_uploadOrUpdateFile(t *testing.T) {
 			err := a.uploadOrUpdateFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.status, tt.parameters.isUpdate, tt.parameters.thumbnailPath, tt.parameters.encryption, tt.parameters.isRepair, tt.parameters.attrs)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				fmt.Println("++++++++++++++++++++++++++++++++++++++++++++")
-				fmt.Println("Expected++++++++++++++++++++++++++++++++++++++++++++", tt.errMsg)
-				fmt.Println("Actual++++++++++++++++++++++++++++++++++++++++++++", common.TopLevelError(err))
 
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error %v", err)
@@ -1128,7 +1125,7 @@ func TestAllocation_RepairRequired(t *testing.T) {
 			}
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			expected := &fileref.FileRef{
@@ -1388,7 +1385,7 @@ func TestAllocation_downloadFile(t *testing.T) {
 			err := a.downloadFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.contentMode, tt.parameters.startBlock, tt.parameters.endBlock, tt.parameters.numBlocks, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error: %v", err)
@@ -1530,7 +1527,7 @@ func TestAllocation_deleteFile(t *testing.T) {
 			err := a.DeleteFile(tt.parameters.path)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1680,7 +1677,7 @@ func TestAllocation_UpdateObjectAttributes(t *testing.T) {
 			err := a.UpdateObjectAttributes(tt.parameters.path, tt.parameters.attrs)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1773,7 +1770,7 @@ func TestAllocation_MoveObject(t *testing.T) {
 			err := a.MoveObject(tt.parameters.path, tt.parameters.destPath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1878,7 +1875,7 @@ func TestAllocation_CopyObject(t *testing.T) {
 			err := a.CopyObject(tt.parameters.path, tt.parameters.destPath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1983,7 +1980,7 @@ func TestAllocation_RenameObject(t *testing.T) {
 			err := a.RenameObject(tt.parameters.path, tt.parameters.destName)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2071,7 +2068,7 @@ func TestAllocation_AddCollaborator(t *testing.T) {
 			err := a.AddCollaborator(tt.parameters.filePath, tt.parameters.collaboratorID)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2159,7 +2156,7 @@ func TestAllocation_RemoveCollaborator(t *testing.T) {
 			err := a.RemoveCollaborator(tt.parameters.filePath, tt.parameters.collaboratorID)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2258,7 +2255,7 @@ func TestAllocation_GetFileMeta(t *testing.T) {
 			got, err := a.GetFileMeta(tt.parameters.path)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2397,7 +2394,7 @@ func TestAllocation_GetAuthTicket(t *testing.T) {
 			at, err := a.GetAuthTicket(tt.parameters.path, tt.parameters.filename, tt.parameters.referenceType, tt.parameters.refereeClientID, tt.parameters.refereeEncryptionPublicKey)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2448,7 +2445,7 @@ func TestAllocation_CancelUpload(t *testing.T) {
 			err := a.CancelUpload(tt.parameters.localpath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2624,7 +2621,7 @@ func TestAllocation_CommitFolderChange(t *testing.T) {
 			_, err := a.CommitFolderChange(tt.parameters.operation, tt.parameters.preValue, tt.parameters.currValue)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2768,7 +2765,7 @@ func TestAllocation_ListDirFromAuthTicket(t *testing.T) {
 			got, err := a.ListDirFromAuthTicket(tt.parameters.authTicket, tt.parameters.lookupHash)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2944,7 +2941,7 @@ func TestAllocation_downloadFromAuthTicket(t *testing.T) {
 			err := a.downloadFromAuthTicket(tt.parameters.localPath, tt.parameters.authTicket, tt.parameters.lookupHash, tt.parameters.startBlock, tt.parameters.endBlock, tt.parameters.numBlocks, tt.parameters.remoteFilename, tt.parameters.contentMode, tt.parameters.rxPay, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3064,7 +3061,7 @@ func TestAllocation_listDir(t *testing.T) {
 			got, err := a.listDir(tt.parameters.path, tt.parameters.consensusThresh, tt.parameters.fullConsensus)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3190,7 +3187,7 @@ func TestAllocation_GetFileMetaFromAuthTicket(t *testing.T) {
 			got, err := a.GetFileMetaFromAuthTicket(tt.parameters.authTicket, tt.parameters.lookupHash)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3435,7 +3432,7 @@ func TestAllocation_CommitMetaTransaction(t *testing.T) {
 			}
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3523,7 +3520,7 @@ func TestAllocation_StartRepair(t *testing.T) {
 			err := a.StartRepair(tt.parameters.localPath, tt.parameters.pathToRepair, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3564,7 +3561,7 @@ func TestAllocation_CancelRepair(t *testing.T) {
 			err := a.CancelRepair()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -196,8 +197,8 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanImplicitLimit128(t *testing.T)
 	var expectedErr = "allocation requires [129] blobbers, which is greater than the maximum permitted number of [128]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
-	} else if err.Error() != expectedErr {
-		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	} else if common.TopLevelError(err) != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, common.TopLevelError(err))
 	}
 }
 
@@ -220,8 +221,8 @@ func TestThrowErrorWhenBlobbersRequiredGreaterThanExplicitLimit(t *testing.T) {
 	var expectedErr = "allocation requires [11] blobbers, which is greater than the maximum permitted number of [10]. reduce number of data or parity shards and try again"
 	if err == nil {
 		t.Errorf("uploadOrUpdateFile() = expected error  but was %v", nil)
-	} else if err.Error() != expectedErr {
-		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, err.Error())
+	} else if common.TopLevelError(err) != expectedErr {
+		t.Errorf("uploadOrUpdateFile() = expected error message to be %v  but was %v", expectedErr, common.TopLevelError(err))
 	}
 }
 
@@ -611,7 +612,7 @@ func TestAllocation_RepairFile(t *testing.T) {
 			err := a.RepairFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.status)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error %v", err)
@@ -973,7 +974,11 @@ func TestAllocation_uploadOrUpdateFile(t *testing.T) {
 			err := a.uploadOrUpdateFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.status, tt.parameters.isUpdate, tt.parameters.thumbnailPath, tt.parameters.encryption, tt.parameters.isRepair, tt.parameters.attrs)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				fmt.Println("++++++++++++++++++++++++++++++++++++++++++++")
+				fmt.Println("Expected++++++++++++++++++++++++++++++++++++++++++++", tt.errMsg)
+				fmt.Println("Actual++++++++++++++++++++++++++++++++++++++++++++", common.TopLevelError(err))
+
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error %v", err)
@@ -1123,7 +1128,7 @@ func TestAllocation_RepairRequired(t *testing.T) {
 			}
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			expected := &fileref.FileRef{
@@ -1383,7 +1388,7 @@ func TestAllocation_downloadFile(t *testing.T) {
 			err := a.downloadFile(tt.parameters.localPath, tt.parameters.remotePath, tt.parameters.contentMode, tt.parameters.startBlock, tt.parameters.endBlock, tt.parameters.numBlocks, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "Unexpected error: %v", err)
@@ -1525,7 +1530,7 @@ func TestAllocation_deleteFile(t *testing.T) {
 			err := a.DeleteFile(tt.parameters.path)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1675,7 +1680,7 @@ func TestAllocation_UpdateObjectAttributes(t *testing.T) {
 			err := a.UpdateObjectAttributes(tt.parameters.path, tt.parameters.attrs)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1768,7 +1773,7 @@ func TestAllocation_MoveObject(t *testing.T) {
 			err := a.MoveObject(tt.parameters.path, tt.parameters.destPath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1873,7 +1878,7 @@ func TestAllocation_CopyObject(t *testing.T) {
 			err := a.CopyObject(tt.parameters.path, tt.parameters.destPath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -1978,7 +1983,7 @@ func TestAllocation_RenameObject(t *testing.T) {
 			err := a.RenameObject(tt.parameters.path, tt.parameters.destName)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2066,7 +2071,7 @@ func TestAllocation_AddCollaborator(t *testing.T) {
 			err := a.AddCollaborator(tt.parameters.filePath, tt.parameters.collaboratorID)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2154,7 +2159,7 @@ func TestAllocation_RemoveCollaborator(t *testing.T) {
 			err := a.RemoveCollaborator(tt.parameters.filePath, tt.parameters.collaboratorID)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2253,7 +2258,7 @@ func TestAllocation_GetFileMeta(t *testing.T) {
 			got, err := a.GetFileMeta(tt.parameters.path)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2392,7 +2397,7 @@ func TestAllocation_GetAuthTicket(t *testing.T) {
 			at, err := a.GetAuthTicket(tt.parameters.path, tt.parameters.filename, tt.parameters.referenceType, tt.parameters.refereeClientID, tt.parameters.refereeEncryptionPublicKey)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2443,7 +2448,7 @@ func TestAllocation_CancelUpload(t *testing.T) {
 			err := a.CancelUpload(tt.parameters.localpath)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2619,7 +2624,7 @@ func TestAllocation_CommitFolderChange(t *testing.T) {
 			_, err := a.CommitFolderChange(tt.parameters.operation, tt.parameters.preValue, tt.parameters.currValue)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2763,7 +2768,7 @@ func TestAllocation_ListDirFromAuthTicket(t *testing.T) {
 			got, err := a.ListDirFromAuthTicket(tt.parameters.authTicket, tt.parameters.lookupHash)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -2939,7 +2944,7 @@ func TestAllocation_downloadFromAuthTicket(t *testing.T) {
 			err := a.downloadFromAuthTicket(tt.parameters.localPath, tt.parameters.authTicket, tt.parameters.lookupHash, tt.parameters.startBlock, tt.parameters.endBlock, tt.parameters.numBlocks, tt.parameters.remoteFilename, tt.parameters.contentMode, tt.parameters.rxPay, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3059,7 +3064,7 @@ func TestAllocation_listDir(t *testing.T) {
 			got, err := a.listDir(tt.parameters.path, tt.parameters.consensusThresh, tt.parameters.fullConsensus)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3185,7 +3190,7 @@ func TestAllocation_GetFileMetaFromAuthTicket(t *testing.T) {
 			got, err := a.GetFileMetaFromAuthTicket(tt.parameters.authTicket, tt.parameters.lookupHash)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3430,7 +3435,7 @@ func TestAllocation_CommitMetaTransaction(t *testing.T) {
 			}
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3518,7 +3523,7 @@ func TestAllocation_StartRepair(t *testing.T) {
 			err := a.StartRepair(tt.parameters.localPath, tt.parameters.pathToRepair, tt.parameters.statusCallback)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)
@@ -3559,7 +3564,7 @@ func TestAllocation_CancelRepair(t *testing.T) {
 			err := a.CancelRepair()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "unexpected error: %v", err)

--- a/zboxcore/sdk/attributesworker.go
+++ b/zboxcore/sdk/attributesworker.go
@@ -130,7 +130,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	ar.wg.Wait()
 
 	if !ar.isConsensusOk() {
-		return errors.NewError("Update attributes failed: request failed, operation failed")
+		return errors.New("Update attributes failed: request failed, operation failed")
 	}
 
 	ar.consensus = 0
@@ -181,7 +181,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	}
 
 	if !ar.isConsensusOk() {
-		return errors.NewError("Delete failed: Commit consensus failed")
+		return errors.New("Delete failed: Commit consensus failed")
 	}
 
 	return nil

--- a/zboxcore/sdk/attributesworker.go
+++ b/zboxcore/sdk/attributesworker.go
@@ -130,7 +130,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	ar.wg.Wait()
 
 	if !ar.isConsensusOk() {
-		return common.NewErrorMessage("Update attributes failed: request failed, operation failed")
+		return common.NewError("Update attributes failed: request failed, operation failed")
 	}
 
 	ar.consensus = 0
@@ -181,7 +181,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	}
 
 	if !ar.isConsensusOk() {
-		return common.NewErrorMessage("Delete failed: Commit consensus failed")
+		return common.NewError("Delete failed: Commit consensus failed")
 	}
 
 	return nil

--- a/zboxcore/sdk/attributesworker.go
+++ b/zboxcore/sdk/attributesworker.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"math/bits"
 	"mime/multipart"
@@ -11,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
@@ -130,8 +130,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	ar.wg.Wait()
 
 	if !ar.isConsensusOk() {
-		return fmt.Errorf("Update attributes failed: " +
-			"request failed, operation failed")
+		return common.NewErrorMessage("Update attributes failed: request failed, operation failed")
 	}
 
 	ar.consensus = 0
@@ -182,7 +181,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	}
 
 	if !ar.isConsensusOk() {
-		return fmt.Errorf("Delete failed: Commit consensus failed")
+		return common.NewErrorMessage("Delete failed: Commit consensus failed")
 	}
 
 	return nil

--- a/zboxcore/sdk/attributesworker.go
+++ b/zboxcore/sdk/attributesworker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
@@ -130,7 +130,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	ar.wg.Wait()
 
 	if !ar.isConsensusOk() {
-		return common.NewError("Update attributes failed: request failed, operation failed")
+		return errors.NewError("Update attributes failed: request failed, operation failed")
 	}
 
 	ar.consensus = 0
@@ -181,7 +181,7 @@ func (ar *AttributesRequest) ProcessAttributes() (err error) {
 	}
 
 	if !ar.isConsensusOk() {
-		return common.NewError("Delete failed: Commit consensus failed")
+		return errors.NewError("Delete failed: Commit consensus failed")
 	}
 
 	return nil

--- a/zboxcore/sdk/attributesworker_test.go
+++ b/zboxcore/sdk/attributesworker_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -171,7 +172,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -219,7 +220,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 			_, err := req.updateBlobberObjectAttributes(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -412,7 +413,7 @@ func TestAttributesRequest_ProcessAttributes(t *testing.T) {
 			err := req.ProcessAttributes()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/attributesworker_test.go
+++ b/zboxcore/sdk/attributesworker_test.go
@@ -75,7 +75,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 				}, nil)
 			},
 			wantErr: true,
-			errMsg:  "Object tree error response: Status: 400 -  ",
+			errMsg:  "400: Object tree error response: Body:  ",
 		},
 		{
 			name: "Test_Update_Blobber_Object_Attributes_Failed",
@@ -171,7 +171,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -219,7 +219,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 			_, err := req.updateBlobberObjectAttributes(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -412,7 +412,7 @@ func TestAttributesRequest_ProcessAttributes(t *testing.T) {
 			err := req.ProcessAttributes()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/attributesworker_test.go
+++ b/zboxcore/sdk/attributesworker_test.go
@@ -172,7 +172,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -220,7 +220,7 @@ func TestAttributesRequest_updateBlobberObjectAttributes(t *testing.T) {
 			_, err := req.updateBlobberObjectAttributes(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -413,7 +413,7 @@ func TestAttributesRequest_ProcessAttributes(t *testing.T) {
 			err := req.ProcessAttributes()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/authticket.go
+++ b/zboxcore/sdk/authticket.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	"github.com/0chain/gosdk/zboxcore/marker"
 )
@@ -22,12 +22,12 @@ func InitAuthTicket(authTicket string) *AuthTicket {
 func (at *AuthTicket) IsDir() (bool, error) {
 	sEnc, err := base64.StdEncoding.DecodeString(at.b64Ticket)
 	if err != nil {
-		return false, common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return false, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	authTicket := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, authTicket)
 	if err != nil {
-		return false, common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return false, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return authTicket.RefType == fileref.DIRECTORY, nil
 }
@@ -35,12 +35,12 @@ func (at *AuthTicket) IsDir() (bool, error) {
 func (at *AuthTicket) GetFileName() (string, error) {
 	sEnc, err := base64.StdEncoding.DecodeString(at.b64Ticket)
 	if err != nil {
-		return "", common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return "", errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	authTicket := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, authTicket)
 	if err != nil {
-		return "", common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return "", errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return authTicket.FileName, nil
 }
@@ -48,12 +48,12 @@ func (at *AuthTicket) GetFileName() (string, error) {
 func (at *AuthTicket) GetLookupHash() (string, error) {
 	sEnc, err := base64.StdEncoding.DecodeString(at.b64Ticket)
 	if err != nil {
-		return "", common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return "", errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	authTicket := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, authTicket)
 	if err != nil {
-		return "", common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return "", errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return authTicket.FilePathHash, nil
 }

--- a/zboxcore/sdk/authticket.go
+++ b/zboxcore/sdk/authticket.go
@@ -22,12 +22,12 @@ func InitAuthTicket(authTicket string) *AuthTicket {
 func (at *AuthTicket) IsDir() (bool, error) {
 	sEnc, err := base64.StdEncoding.DecodeString(at.b64Ticket)
 	if err != nil {
-		return false, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return false, errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	authTicket := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, authTicket)
 	if err != nil {
-		return false, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return false, errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return authTicket.RefType == fileref.DIRECTORY, nil
 }
@@ -35,12 +35,12 @@ func (at *AuthTicket) IsDir() (bool, error) {
 func (at *AuthTicket) GetFileName() (string, error) {
 	sEnc, err := base64.StdEncoding.DecodeString(at.b64Ticket)
 	if err != nil {
-		return "", errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return "", errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	authTicket := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, authTicket)
 	if err != nil {
-		return "", errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return "", errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return authTicket.FileName, nil
 }
@@ -48,12 +48,12 @@ func (at *AuthTicket) GetFileName() (string, error) {
 func (at *AuthTicket) GetLookupHash() (string, error) {
 	sEnc, err := base64.StdEncoding.DecodeString(at.b64Ticket)
 	if err != nil {
-		return "", errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return "", errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	authTicket := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, authTicket)
 	if err != nil {
-		return "", errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return "", errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return authTicket.FilePathHash, nil
 }

--- a/zboxcore/sdk/blockdownloadworker.go
+++ b/zboxcore/sdk/blockdownloadworker.go
@@ -128,7 +128,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 
 		if req.blobber.IsSkip() {
 			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx,
-				err: fmt.Errorf("skip blobber by previous errors")}
+				err: common.NewErrorMessage("skip blobber by previous errors")}
 			return
 		}
 
@@ -142,14 +142,14 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 		rm.ReadCounter = getBlobberReadCtr(req.blobber) + req.numBlocks
 		err := rm.Sign()
 		if err != nil {
-			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx, err: fmt.Errorf("Error: Signing readmarker failed: %s", err.Error())}
+			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx, err: common.WrapWithMessage(err, "Error: Signing readmarker failed")}
 			return
 		}
 		body := new(bytes.Buffer)
 		formWriter := multipart.NewWriter(body)
 		rmData, err := json.Marshal(rm)
 		if err != nil {
-			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx, err: fmt.Errorf("Error creating readmarker: %s", err.Error())}
+			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx, err: common.WrapWithMessage(err, "Error creating readmarker")}
 			return
 		}
 		if len(req.remotefilepath) > 0 {
@@ -175,7 +175,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 		formWriter.Close()
 		httpreq, err := zboxutil.NewDownloadRequest(req.blobber.Baseurl, req.allocationTx, body)
 		if err != nil {
-			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx, err: fmt.Errorf("Error creating download request: %s", err.Error())}
+			req.result <- &downloadBlock{Success: false, idx: req.blobberIdx, err: common.WrapWithMessage(err, "Error creating download request")}
 			return
 		}
 		httpreq.Header.Add("Content-Type", formWriter.FormDataContentType())
@@ -194,7 +194,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 
 				response, err := ioutil.ReadAll(resp.Body)
 				// if err != nil {
-				// 	return fmt.Errorf("[%d] Read error:%s\n", req.blobberIdx, err.Error())
+					// return common.WrapWithMessage(err, fmt.Sprintf("[%d] Read error:\n", req.blobberIdx))
 				// }
 				var rspData downloadBlock
 				rspData.idx = req.blobberIdx
@@ -212,7 +212,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 					incBlobberReadCtr(req.blobber, req.numBlocks)
 					req.result <- &rspData
 					return nil
-					//return fmt.Errorf("[%d] Json decode error:%s\n", req.blobberIdx, err.Error())
+					// return common.WrapWithMessage(err, fmt.Sprintf("[%d] Json decode error:\n", req.blobberIdx))
 				}
 				// if rspData.Success {
 				// 	elapsed := time.Since(start)
@@ -228,7 +228,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 					Logger.Info("Will be retrying download")
 					setBlobberReadCtr(req.blobber, rspData.LatestRM.ReadCounter)
 					shouldRetry = true
-					return fmt.Errorf("Need to retry the download")
+					return common.NewErrorMessage("Need to retry the download")
 				}
 
 			} else {
@@ -236,7 +236,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 				if err != nil {
 					return err
 				}
-				err = fmt.Errorf("Response Error: %s", string(resp_body))
+				err = common.NewErrorMessage(fmt.Sprintf("Response Error: %s", string(resp_body)))
 				if strings.Contains(err.Error(), "not_enough_tokens") {
 					shouldRetry, retry = false, 3 // don't repeat
 					req.blobber.SetSkip(true)

--- a/zboxcore/sdk/collaboratorworker_test.go
+++ b/zboxcore/sdk/collaboratorworker_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -173,7 +173,7 @@ func TestCollaboratorRequest_updateCollaboratorToBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName)
 				})).Return(&http.Response{
@@ -363,7 +363,7 @@ func TestCollaboratorRequest_removeCollaboratorFromBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName)
 				})).Return(&http.Response{

--- a/zboxcore/sdk/collaboratorworker_test.go
+++ b/zboxcore/sdk/collaboratorworker_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -172,7 +173,7 @@ func TestCollaboratorRequest_updateCollaboratorToBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName)
 				})).Return(&http.Response{
@@ -362,7 +363,7 @@ func TestCollaboratorRequest_removeCollaboratorFromBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName)
 				})).Return(&http.Response{

--- a/zboxcore/sdk/collaboratorworker_test.go
+++ b/zboxcore/sdk/collaboratorworker_test.go
@@ -173,7 +173,7 @@ func TestCollaboratorRequest_updateCollaboratorToBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return strings.HasPrefix(req.URL.Path, testName)
 				})).Return(&http.Response{
@@ -363,7 +363,7 @@ func TestCollaboratorRequest_removeCollaboratorFromBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return strings.HasPrefix(req.URL.Path, testName)
 				})).Return(&http.Response{

--- a/zboxcore/sdk/commitmetaworker.go
+++ b/zboxcore/sdk/commitmetaworker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/transaction"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/client"
@@ -73,7 +73,7 @@ func (req *CommitMetaRequest) processCommitMetaRequest() {
 		return
 	}
 	if t == nil {
-		err = common.NewError("transaction_validation_failed", "Failed to get the transaction confirmation")
+		err = errors.NewError("transaction_validation_failed", "Failed to get the transaction confirmation")
 		req.status.CommitMetaCompleted(commitMetaDataString, "", err)
 		return
 	}

--- a/zboxcore/sdk/commitmetaworker.go
+++ b/zboxcore/sdk/commitmetaworker.go
@@ -73,7 +73,7 @@ func (req *CommitMetaRequest) processCommitMetaRequest() {
 		return
 	}
 	if t == nil {
-		err = errors.NewError("transaction_validation_failed", "Failed to get the transaction confirmation")
+		err = errors.New("transaction_validation_failed", "Failed to get the transaction confirmation")
 		req.status.CommitMetaCompleted(commitMetaDataString, "", err)
 		return
 	}

--- a/zboxcore/sdk/commitworker.go
+++ b/zboxcore/sdk/commitworker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -126,7 +127,7 @@ func (commitreq *CommitRequest) processCommit() {
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return common.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Reference path error response: Status: %d - %s ", resp.StatusCode, string(resp_body)))
+			return errors.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Reference path error response: Status: %d - %s ", resp.StatusCode, string(resp_body)))
 			
 		} else {
 			//Logger.Info("Reference path:", string(resp_body))
@@ -259,7 +260,7 @@ func (req *CommitRequest) commitBlobber(rootRef *fileref.Ref, latestWM *marker.W
 		}
 		if resp.StatusCode != http.StatusOK {
 			Logger.Error(req.blobber.Baseurl, " Commit response:", string(resp_body))
-			return common.NewError("commit_error", string(resp_body))
+			return errors.NewError("commit_error", string(resp_body))
 		}
 		return nil
 	})
@@ -293,7 +294,7 @@ func (commitreq *CommitRequest) calculateHashRequest(ctx context.Context, paths 
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return common.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Calculate hash error response: Body: %s ", string(resp_body)))
+			return errors.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Calculate hash error response: Body: %s ", string(resp_body)))
 		}
 		return nil
 	})

--- a/zboxcore/sdk/commitworker.go
+++ b/zboxcore/sdk/commitworker.go
@@ -127,8 +127,8 @@ func (commitreq *CommitRequest) processCommit() {
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return errors.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Reference path error response: Status: %d - %s ", resp.StatusCode, string(resp_body)))
-			
+			return errors.New(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Reference path error response: Status: %d - %s ", resp.StatusCode, string(resp_body)))
+
 		} else {
 			//Logger.Info("Reference path:", string(resp_body))
 			err = json.Unmarshal(resp_body, &lR)
@@ -260,7 +260,7 @@ func (req *CommitRequest) commitBlobber(rootRef *fileref.Ref, latestWM *marker.W
 		}
 		if resp.StatusCode != http.StatusOK {
 			Logger.Error(req.blobber.Baseurl, " Commit response:", string(resp_body))
-			return errors.NewError("commit_error", string(resp_body))
+			return errors.New("commit_error", string(resp_body))
 		}
 		return nil
 	})
@@ -294,7 +294,7 @@ func (commitreq *CommitRequest) calculateHashRequest(ctx context.Context, paths 
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return errors.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Calculate hash error response: Body: %s ", string(resp_body)))
+			return errors.New(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Calculate hash error response: Body: %s ", string(resp_body)))
 		}
 		return nil
 	})

--- a/zboxcore/sdk/commitworker.go
+++ b/zboxcore/sdk/commitworker.go
@@ -126,7 +126,8 @@ func (commitreq *CommitRequest) processCommit() {
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Reference path error response: Status: %d - %s ", resp.StatusCode, string(resp_body))
+			return common.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Reference path error response: Status: %d - %s ", resp.StatusCode, string(resp_body)))
+			
 		} else {
 			//Logger.Info("Reference path:", string(resp_body))
 			err = json.Unmarshal(resp_body, &lR)
@@ -292,7 +293,7 @@ func (commitreq *CommitRequest) calculateHashRequest(ctx context.Context, paths 
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Calculate hash error response: Status: %d - %s ", resp.StatusCode, string(resp_body))
+			return common.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Calculate hash error response: Body: %s ", string(resp_body)))
 		}
 		return nil
 	})

--- a/zboxcore/sdk/common.go
+++ b/zboxcore/sdk/common.go
@@ -40,7 +40,7 @@ func getObjectTreeFromBlobber(ctx context.Context, allocationID, allocationTx st
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return errors.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Object tree error response: Body: %s ", string(resp_body)))
+			return errors.New(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Object tree error response: Body: %s ", string(resp_body)))
 		} else {
 			Logger.Info("Object tree:", string(resp_body))
 			err = json.Unmarshal(resp_body, &lR)

--- a/zboxcore/sdk/common.go
+++ b/zboxcore/sdk/common.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -38,7 +40,7 @@ func getObjectTreeFromBlobber(ctx context.Context, allocationID, allocationTx st
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Object tree error response: Status: %d - %s ", resp.StatusCode, string(resp_body))
+			return common.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Object tree error response: Body: %s ", string(resp_body)))
 		} else {
 			Logger.Info("Object tree:", string(resp_body))
 			err = json.Unmarshal(resp_body, &lR)

--- a/zboxcore/sdk/common.go
+++ b/zboxcore/sdk/common.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -40,7 +40,7 @@ func getObjectTreeFromBlobber(ctx context.Context, allocationID, allocationTx st
 			return err
 		}
 		if resp.StatusCode != http.StatusOK {
-			return common.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Object tree error response: Body: %s ", string(resp_body)))
+			return errors.NewError(strconv.Itoa(resp.StatusCode), fmt.Sprintf("Object tree error response: Body: %s ", string(resp_body)))
 		} else {
 			Logger.Info("Object tree:", string(resp_body))
 			err = json.Unmarshal(resp_body, &lR)

--- a/zboxcore/sdk/copyworker.go
+++ b/zboxcore/sdk/copyworker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
@@ -103,7 +103,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return common.NewError("Copy failed: Copy request failed. Operation failed.")
+		return errors.NewError("Copy failed: Copy request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -147,7 +147,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	}
 
 	if !req.isConsensusOk() {
-		return common.NewError("Copy failed: Commit consensus failed")
+		return errors.NewError("Copy failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/copyworker.go
+++ b/zboxcore/sdk/copyworker.go
@@ -103,7 +103,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return errors.NewError("Copy failed: Copy request failed. Operation failed.")
+		return errors.New("Copy failed: Copy request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -147,7 +147,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	}
 
 	if !req.isConsensusOk() {
-		return errors.NewError("Copy failed: Commit consensus failed")
+		return errors.New("Copy failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/copyworker.go
+++ b/zboxcore/sdk/copyworker.go
@@ -103,7 +103,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage("Copy failed: Copy request failed. Operation failed.")
+		return common.NewError("Copy failed: Copy request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -147,7 +147,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	}
 
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage("Copy failed: Commit consensus failed")
+		return common.NewError("Copy failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/copyworker.go
+++ b/zboxcore/sdk/copyworker.go
@@ -3,14 +3,15 @@ package sdk
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"github.com/0chain/gosdk/zboxcore/fileref"
 	"io/ioutil"
 	"math/bits"
 	"mime/multipart"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -102,7 +103,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Copy failed: Copy request failed. Operation failed.")
+		return common.NewErrorMessage("Copy failed: Copy request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -146,7 +147,7 @@ func (req *CopyRequest) ProcessCopy() error {
 	}
 
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Copy failed: Commit consensus failed")
+		return common.NewErrorMessage("Copy failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/copyworker_test.go
+++ b/zboxcore/sdk/copyworker_test.go
@@ -166,7 +166,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -210,7 +210,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 			_, err := req.copyBlobberObject(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -400,7 +400,7 @@ func TestCopyRequest_ProcessCopy(t *testing.T) {
 			err := req.ProcessCopy()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/copyworker_test.go
+++ b/zboxcore/sdk/copyworker_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -166,7 +166,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -210,7 +210,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 			_, err := req.copyBlobberObject(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -400,7 +400,7 @@ func TestCopyRequest_ProcessCopy(t *testing.T) {
 			err := req.ProcessCopy()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/copyworker_test.go
+++ b/zboxcore/sdk/copyworker_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -74,7 +75,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 				}, nil)
 			},
 			wantErr: true,
-			errMsg:  "Object tree error response: Status: 400 -  ",
+			errMsg:  "400: Object tree error response: Body:  ",
 		},
 		{
 			name: "Test_Copy_Blobber_Object_Failed",
@@ -165,7 +166,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -209,7 +210,7 @@ func TestCopyRequest_copyBlobberObject(t *testing.T) {
 			_, err := req.copyBlobberObject(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -399,7 +400,7 @@ func TestCopyRequest_ProcessCopy(t *testing.T) {
 			err := req.ProcessCopy()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
@@ -120,7 +120,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return common.NewError(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
+		return errors.NewError(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 
 	req.consensus = 0
@@ -163,7 +163,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	}
 
 	if !req.isConsensusOk() {
-		return common.NewError("Delete failed: Commit consensus failed")
+		return errors.NewError("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -120,7 +120,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
+		return common.NewError(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 
 	req.consensus = 0
@@ -163,7 +163,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	}
 
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage("Delete failed: Commit consensus failed")
+		return common.NewError("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -120,7 +120,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return errors.NewError(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
+		return errors.New(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 
 	req.consensus = 0
@@ -163,7 +163,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	}
 
 	if !req.isConsensusOk() {
-		return errors.NewError("Delete failed: Commit consensus failed")
+		return errors.New("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
@@ -119,7 +120,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk())
+		return common.NewErrorMessage(fmt.Sprintf("Delete failed: Success_rate:%2f, expected:%2f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 
 	req.consensus = 0
@@ -162,7 +163,7 @@ func (req *DeleteRequest) ProcessDelete() error {
 	}
 
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Delete failed: Commit consensus failed")
+		return common.NewErrorMessage("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/deleteworker_test.go
+++ b/zboxcore/sdk/deleteworker_test.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -154,7 +155,7 @@ func TestDeleteRequest_deleteBlobberFile(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "DELETE" &&
@@ -383,7 +384,7 @@ func TestDeleteRequest_ProcessDelete(t *testing.T) {
 			err := req.ProcessDelete()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.Contains(err.Error(), tt.errMsg, "expected error contains '%s'", tt.errMsg)
+				require.Contains(common.TopLevelError(err), tt.errMsg, "expected error contains '%s'", tt.errMsg)
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/deleteworker_test.go
+++ b/zboxcore/sdk/deleteworker_test.go
@@ -155,7 +155,7 @@ func TestDeleteRequest_deleteBlobberFile(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "DELETE" &&
@@ -384,7 +384,7 @@ func TestDeleteRequest_ProcessDelete(t *testing.T) {
 			err := req.ProcessDelete()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.Contains(errors.TopLevelError(err), tt.errMsg, "expected error contains '%s'", tt.errMsg)
+				require.Contains(errors.Top(err), tt.errMsg, "expected error contains '%s'", tt.errMsg)
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/deleteworker_test.go
+++ b/zboxcore/sdk/deleteworker_test.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -155,7 +155,7 @@ func TestDeleteRequest_deleteBlobberFile(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "DELETE" &&
@@ -384,7 +384,7 @@ func TestDeleteRequest_ProcessDelete(t *testing.T) {
 			err := req.ProcessDelete()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.Contains(common.TopLevelError(err), tt.errMsg, "expected error contains '%s'", tt.errMsg)
+				require.Contains(errors.TopLevelError(err), tt.errMsg, "expected error contains '%s'", tt.errMsg)
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -159,12 +159,12 @@ func (req *DownloadRequest) downloadBlock(blockNum int64, blockChunksMax int) ([
 	}
 	erasureencoder, err := encoder.NewEncoder(req.datashards, req.parityshards)
 	if err != nil {
-		return []byte{}, errors.WrapError(err, "encoder init error")
+		return []byte{}, errors.Wrap(err, "encoder init error")
 	}
 	for blockNum := 0; blockNum < decodeNumBlocks; blockNum++ {
 		data, err := erasureencoder.Decode(shards[blockNum], decodeLen[blockNum])
 		if err != nil {
-			return []byte{}, errors.WrapError(err, "Block decode error")
+			return []byte{}, errors.Wrap(err, "Block decode error")
 		}
 		retData = append(retData, data...)
 	}
@@ -194,7 +194,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	req.downloadMask, fileRef, _ = listReq.getFileConsensusFromBlobbers()
 	if req.downloadMask.Equals64(0) || fileRef == nil {
 		if req.statusCallback != nil {
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.NewError("No minimum consensus for file meta data of file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.New("No minimum consensus for file meta data of file"))
 		}
 		return
 	}
@@ -221,7 +221,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	if err != nil {
 		if req.statusCallback != nil {
 			Logger.Error(err.Error())
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.WrapError(err, "Can't create local file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.Wrap(err, "Can't create local file"))
 		}
 		return
 	}
@@ -260,7 +260,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.WrapError(err, fmt.Sprintf("Download failed for block %d. ", cnt+1)))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.Wrap(err, fmt.Sprintf("Download failed for block %d. ", cnt+1)))
 			}
 			return
 		}
@@ -268,7 +268,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 			req.isDownloadCanceled = false
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.NewError("Download aborted by user"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.New("Download aborted by user"))
 			}
 			return
 		}
@@ -278,7 +278,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.WrapError(err, "Write file failed"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.Wrap(err, "Write file failed"))
 			}
 			return
 		}
@@ -306,7 +306,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if calcHash != expectedHash {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.NewError("File content didn't match with uploaded file"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.New("File content didn't match with uploaded file"))
 			}
 			return
 		}

--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/client"
 	"github.com/0chain/gosdk/zboxcore/encoder"
@@ -158,12 +159,12 @@ func (req *DownloadRequest) downloadBlock(blockNum int64, blockChunksMax int) ([
 	}
 	erasureencoder, err := encoder.NewEncoder(req.datashards, req.parityshards)
 	if err != nil {
-		return []byte{}, fmt.Errorf("encoder init error %s", err.Error())
+		return []byte{}, common.WrapWithMessage(err, "encoder init error")
 	}
 	for blockNum := 0; blockNum < decodeNumBlocks; blockNum++ {
 		data, err := erasureencoder.Decode(shards[blockNum], decodeLen[blockNum])
 		if err != nil {
-			return []byte{}, fmt.Errorf("Block decode error %s", err.Error())
+			return []byte{}, common.WrapWithMessage(err, "Block decode error")
 		}
 		retData = append(retData, data...)
 	}
@@ -193,7 +194,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	req.downloadMask, fileRef, _ = listReq.getFileConsensusFromBlobbers()
 	if req.downloadMask.Equals64(0) || fileRef == nil {
 		if req.statusCallback != nil {
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, fmt.Errorf("No minimum consensus for file meta data of file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewErrorMessage("No minimum consensus for file meta data of file"))
 		}
 		return
 	}
@@ -220,7 +221,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	if err != nil {
 		if req.statusCallback != nil {
 			Logger.Error(err.Error())
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, fmt.Errorf("Can't create local file %s", err.Error()))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapWithMessage(err, "Can't create local file"))
 		}
 		return
 	}
@@ -259,7 +260,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, fmt.Errorf("Download failed for block %d. Error : %s", cnt+1, err.Error()))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapWithMessage(err, fmt.Sprintf("Download failed for block %d. ", cnt+1, )))
 			}
 			return
 		}
@@ -267,7 +268,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 			req.isDownloadCanceled = false
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, fmt.Errorf("Download aborted by user"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewErrorMessage("Download aborted by user"))
 			}
 			return
 		}
@@ -277,7 +278,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, fmt.Errorf("Write file failed : %s", err.Error()))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapWithMessage(err, "Write file failed"))
 			}
 			return
 		}
@@ -305,7 +306,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if calcHash != expectedHash {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, fmt.Errorf("File content didn't match with uploaded file"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewErrorMessage("File content didn't match with uploaded file"))
 			}
 			return
 		}

--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -159,12 +159,12 @@ func (req *DownloadRequest) downloadBlock(blockNum int64, blockChunksMax int) ([
 	}
 	erasureencoder, err := encoder.NewEncoder(req.datashards, req.parityshards)
 	if err != nil {
-		return []byte{}, common.WrapWithMessage(err, "encoder init error")
+		return []byte{}, common.WrapError(err, "encoder init error")
 	}
 	for blockNum := 0; blockNum < decodeNumBlocks; blockNum++ {
 		data, err := erasureencoder.Decode(shards[blockNum], decodeLen[blockNum])
 		if err != nil {
-			return []byte{}, common.WrapWithMessage(err, "Block decode error")
+			return []byte{}, common.WrapError(err, "Block decode error")
 		}
 		retData = append(retData, data...)
 	}
@@ -194,7 +194,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	req.downloadMask, fileRef, _ = listReq.getFileConsensusFromBlobbers()
 	if req.downloadMask.Equals64(0) || fileRef == nil {
 		if req.statusCallback != nil {
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewErrorMessage("No minimum consensus for file meta data of file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewError("No minimum consensus for file meta data of file"))
 		}
 		return
 	}
@@ -221,7 +221,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	if err != nil {
 		if req.statusCallback != nil {
 			Logger.Error(err.Error())
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapWithMessage(err, "Can't create local file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapError(err, "Can't create local file"))
 		}
 		return
 	}
@@ -260,7 +260,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapWithMessage(err, fmt.Sprintf("Download failed for block %d. ", cnt+1, )))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapError(err, fmt.Sprintf("Download failed for block %d. ", cnt+1)))
 			}
 			return
 		}
@@ -268,7 +268,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 			req.isDownloadCanceled = false
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewErrorMessage("Download aborted by user"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewError("Download aborted by user"))
 			}
 			return
 		}
@@ -278,7 +278,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapWithMessage(err, "Write file failed"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapError(err, "Write file failed"))
 			}
 			return
 		}
@@ -306,7 +306,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if calcHash != expectedHash {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewErrorMessage("File content didn't match with uploaded file"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewError("File content didn't match with uploaded file"))
 			}
 			return
 		}

--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/client"
 	"github.com/0chain/gosdk/zboxcore/encoder"
@@ -159,12 +159,12 @@ func (req *DownloadRequest) downloadBlock(blockNum int64, blockChunksMax int) ([
 	}
 	erasureencoder, err := encoder.NewEncoder(req.datashards, req.parityshards)
 	if err != nil {
-		return []byte{}, common.WrapError(err, "encoder init error")
+		return []byte{}, errors.WrapError(err, "encoder init error")
 	}
 	for blockNum := 0; blockNum < decodeNumBlocks; blockNum++ {
 		data, err := erasureencoder.Decode(shards[blockNum], decodeLen[blockNum])
 		if err != nil {
-			return []byte{}, common.WrapError(err, "Block decode error")
+			return []byte{}, errors.WrapError(err, "Block decode error")
 		}
 		retData = append(retData, data...)
 	}
@@ -194,7 +194,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	req.downloadMask, fileRef, _ = listReq.getFileConsensusFromBlobbers()
 	if req.downloadMask.Equals64(0) || fileRef == nil {
 		if req.statusCallback != nil {
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewError("No minimum consensus for file meta data of file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.NewError("No minimum consensus for file meta data of file"))
 		}
 		return
 	}
@@ -221,7 +221,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	if err != nil {
 		if req.statusCallback != nil {
 			Logger.Error(err.Error())
-			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapError(err, "Can't create local file"))
+			req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.WrapError(err, "Can't create local file"))
 		}
 		return
 	}
@@ -260,7 +260,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapError(err, fmt.Sprintf("Download failed for block %d. ", cnt+1)))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.WrapError(err, fmt.Sprintf("Download failed for block %d. ", cnt+1)))
 			}
 			return
 		}
@@ -268,7 +268,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 			req.isDownloadCanceled = false
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewError("Download aborted by user"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.NewError("Download aborted by user"))
 			}
 			return
 		}
@@ -278,7 +278,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if err != nil {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.WrapError(err, "Write file failed"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.WrapError(err, "Write file failed"))
 			}
 			return
 		}
@@ -306,7 +306,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 		if calcHash != expectedHash {
 			os.Remove(req.localpath)
 			if req.statusCallback != nil {
-				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, common.NewError("File content didn't match with uploaded file"))
+				req.statusCallback.Error(req.allocationID, remotePathCallback, OpDownload, errors.NewError("File content didn't match with uploaded file"))
 			}
 			return
 		}

--- a/zboxcore/sdk/filemetaworker.go
+++ b/zboxcore/sdk/filemetaworker.go
@@ -68,14 +68,14 @@ func (req *ListRequest) getFileMetaInfoFromBlobber(blobber *blockchain.StorageNo
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapWithMessage(err, "Error: Resp")
+			return common.WrapError(err, "Error: Resp")
 		}
 		Logger.Info("File Meta result:", string(resp_body))
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileRef)
 			if err != nil {
-				return common.WrapWithMessage(err, "file meta data response parse error")
+				return common.WrapError(err, "file meta data response parse error")
 			}
 			return nil
 		}

--- a/zboxcore/sdk/filemetaworker.go
+++ b/zboxcore/sdk/filemetaworker.go
@@ -68,14 +68,14 @@ func (req *ListRequest) getFileMetaInfoFromBlobber(blobber *blockchain.StorageNo
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.WrapError(err, "Error: Resp")
+			return errors.Wrap(err, "Error: Resp")
 		}
 		Logger.Info("File Meta result:", string(resp_body))
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileRef)
 			if err != nil {
-				return errors.WrapError(err, "file meta data response parse error")
+				return errors.Wrap(err, "file meta data response parse error")
 			}
 			return nil
 		}

--- a/zboxcore/sdk/filemetaworker.go
+++ b/zboxcore/sdk/filemetaworker.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -68,14 +68,14 @@ func (req *ListRequest) getFileMetaInfoFromBlobber(blobber *blockchain.StorageNo
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Error: Resp : %s", err.Error())
+			return common.WrapWithMessage(err, "Error: Resp")
 		}
 		Logger.Info("File Meta result:", string(resp_body))
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileRef)
 			if err != nil {
-				return fmt.Errorf("file meta data response parse error: %s", err.Error())
+				return common.WrapWithMessage(err, "file meta data response parse error")
 			}
 			return nil
 		}

--- a/zboxcore/sdk/filemetaworker.go
+++ b/zboxcore/sdk/filemetaworker.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -68,14 +68,14 @@ func (req *ListRequest) getFileMetaInfoFromBlobber(blobber *blockchain.StorageNo
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapError(err, "Error: Resp")
+			return errors.WrapError(err, "Error: Resp")
 		}
 		Logger.Info("File Meta result:", string(resp_body))
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileRef)
 			if err != nil {
-				return common.WrapError(err, "file meta data response parse error")
+				return errors.WrapError(err, "file meta data response parse error")
 			}
 			return nil
 		}

--- a/zboxcore/sdk/filemetaworker_test.go
+++ b/zboxcore/sdk/filemetaworker_test.go
@@ -4,16 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"github.com/0chain/gosdk/core/zcncrypto"
-	"github.com/0chain/gosdk/zboxcore/blockchain"
-	zclient "github.com/0chain/gosdk/zboxcore/client"
-	"github.com/0chain/gosdk/zboxcore/fileref"
-	"github.com/0chain/gosdk/zboxcore/marker"
-	"github.com/0chain/gosdk/zboxcore/mocks"
-	"github.com/0chain/gosdk/zboxcore/zboxutil"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -23,6 +13,17 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/zcncrypto"
+	"github.com/0chain/gosdk/zboxcore/blockchain"
+	zclient "github.com/0chain/gosdk/zboxcore/client"
+	"github.com/0chain/gosdk/zboxcore/fileref"
+	"github.com/0chain/gosdk/zboxcore/marker"
+	"github.com/0chain/gosdk/zboxcore/mocks"
+	"github.com/0chain/gosdk/zboxcore/zboxutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
@@ -69,7 +70,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, fmt.Errorf(mockErrorMessage))
+				}, common.NewErrorMessage(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,

--- a/zboxcore/sdk/filemetaworker_test.go
+++ b/zboxcore/sdk/filemetaworker_test.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -70,7 +70,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, common.NewError(mockErrorMessage))
+				}, errors.NewError(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,
@@ -133,7 +133,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return req.URL.Path == "Test_Success"+zboxutil.FILE_META_ENDPOINT+mockAllocationTxId &&
 						req.URL.RawPath == "Test_Success"+zboxutil.FILE_META_ENDPOINT+mockAllocationTxId &&
@@ -177,7 +177,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(t, tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(t, tt.errMsg, common.TopLevelError(resp.err))
+				require.EqualValues(t, tt.errMsg, errors.TopLevelError(resp.err))
 				return
 			}
 			require.EqualValues(t, tt.parameters.fileRefToRetrieve, *resp.fileref)

--- a/zboxcore/sdk/filemetaworker_test.go
+++ b/zboxcore/sdk/filemetaworker_test.go
@@ -70,7 +70,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, common.NewErrorMessage(mockErrorMessage))
+				}, common.NewError(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,

--- a/zboxcore/sdk/filemetaworker_test.go
+++ b/zboxcore/sdk/filemetaworker_test.go
@@ -89,7 +89,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 				}, nil)
 			},
 			wantErr: true,
-			errMsg:  "file meta data response parse error: unexpected end of JSON input",
+			errMsg:  "file meta data response parse error",
 		},
 		{
 			name: "Test_Success",
@@ -133,7 +133,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return req.URL.Path == "Test_Success"+zboxutil.FILE_META_ENDPOINT+mockAllocationTxId &&
 						req.URL.RawPath == "Test_Success"+zboxutil.FILE_META_ENDPOINT+mockAllocationTxId &&
@@ -177,7 +177,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(t, tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(t, tt.errMsg, resp.err.Error())
+				require.EqualValues(t, tt.errMsg, common.TopLevelError(resp.err))
 				return
 			}
 			require.EqualValues(t, tt.parameters.fileRefToRetrieve, *resp.fileref)

--- a/zboxcore/sdk/filemetaworker_test.go
+++ b/zboxcore/sdk/filemetaworker_test.go
@@ -70,7 +70,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, errors.NewError(mockErrorMessage))
+				}, errors.New(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,
@@ -133,7 +133,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return req.URL.Path == "Test_Success"+zboxutil.FILE_META_ENDPOINT+mockAllocationTxId &&
 						req.URL.RawPath == "Test_Success"+zboxutil.FILE_META_ENDPOINT+mockAllocationTxId &&
@@ -177,7 +177,7 @@ func TestListRequest_getFileMetaInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(t, tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(t, tt.errMsg, errors.TopLevelError(resp.err))
+				require.EqualValues(t, tt.errMsg, errors.Top(resp.err))
 				return
 			}
 			require.EqualValues(t, tt.parameters.fileRefToRetrieve, *resp.fileref)

--- a/zboxcore/sdk/filestatsworker.go
+++ b/zboxcore/sdk/filestatsworker.go
@@ -77,13 +77,13 @@ func (req *ListRequest) getFileStatsInfoFromBlobber(blobber *blockchain.StorageN
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.WrapError(err, "Error: Resp")
+			return errors.Wrap(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileStats)
 			if err != nil {
-				return errors.WrapError(err, "file stats response parse error")
+				return errors.Wrap(err, "file stats response parse error")
 			}
 			if len(fileStats.WriteMarkerRedeemTxn) > 0 {
 				fileStats.BlockchainAware = true

--- a/zboxcore/sdk/filestatsworker.go
+++ b/zboxcore/sdk/filestatsworker.go
@@ -77,13 +77,13 @@ func (req *ListRequest) getFileStatsInfoFromBlobber(blobber *blockchain.StorageN
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapWithMessage(err, "Error: Resp")
+			return common.WrapError(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileStats)
 			if err != nil {
-				return common.WrapWithMessage(err, "file stats response parse error")
+				return common.WrapError(err, "file stats response parse error")
 			}
 			if len(fileStats.WriteMarkerRedeemTxn) > 0 {
 				fileStats.BlockchainAware = true

--- a/zboxcore/sdk/filestatsworker.go
+++ b/zboxcore/sdk/filestatsworker.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -77,13 +77,13 @@ func (req *ListRequest) getFileStatsInfoFromBlobber(blobber *blockchain.StorageN
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Error: Resp : %s", err.Error())
+			return common.WrapWithMessage(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileStats)
 			if err != nil {
-				return fmt.Errorf("file stats response parse error: %s", err.Error())
+				return common.WrapWithMessage(err, "file stats response parse error")
 			}
 			if len(fileStats.WriteMarkerRedeemTxn) > 0 {
 				fileStats.BlockchainAware = true

--- a/zboxcore/sdk/filestatsworker.go
+++ b/zboxcore/sdk/filestatsworker.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
@@ -77,13 +77,13 @@ func (req *ListRequest) getFileStatsInfoFromBlobber(blobber *blockchain.StorageN
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapError(err, "Error: Resp")
+			return errors.WrapError(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileStats)
 			if err != nil {
-				return common.WrapError(err, "file stats response parse error")
+				return errors.WrapError(err, "file stats response parse error")
 			}
 			if len(fileStats.WriteMarkerRedeemTxn) > 0 {
 				fileStats.BlockchainAware = true

--- a/zboxcore/sdk/filestatsworker_test.go
+++ b/zboxcore/sdk/filestatsworker_test.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -74,7 +74,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, common.NewError(mockErrorMessage))
+				}, errors.NewError(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,
@@ -167,7 +167,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(t, tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(t, tt.errMsg, common.TopLevelError(resp.err))
+				require.EqualValues(t, tt.errMsg, errors.TopLevelError(resp.err))
 				return
 			}
 			require.EqualValues(t, tt.parameters.fileStatsFinal, *resp.filestats)

--- a/zboxcore/sdk/filestatsworker_test.go
+++ b/zboxcore/sdk/filestatsworker_test.go
@@ -4,16 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
-	"github.com/0chain/gosdk/core/encryption"
-	"github.com/0chain/gosdk/core/zcncrypto"
-	"github.com/0chain/gosdk/zboxcore/blockchain"
-	zclient "github.com/0chain/gosdk/zboxcore/client"
-	"github.com/0chain/gosdk/zboxcore/fileref"
-	"github.com/0chain/gosdk/zboxcore/mocks"
-	"github.com/0chain/gosdk/zboxcore/zboxutil"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -23,6 +13,17 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/encryption"
+	"github.com/0chain/gosdk/core/zcncrypto"
+	"github.com/0chain/gosdk/zboxcore/blockchain"
+	zclient "github.com/0chain/gosdk/zboxcore/client"
+	"github.com/0chain/gosdk/zboxcore/fileref"
+	"github.com/0chain/gosdk/zboxcore/mocks"
+	"github.com/0chain/gosdk/zboxcore/zboxutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
@@ -73,7 +74,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, fmt.Errorf(mockErrorMessage))
+				}, common.NewErrorMessage(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,

--- a/zboxcore/sdk/filestatsworker_test.go
+++ b/zboxcore/sdk/filestatsworker_test.go
@@ -74,7 +74,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, errors.NewError(mockErrorMessage))
+				}, errors.New(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,
@@ -167,7 +167,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(t, tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(t, tt.errMsg, errors.TopLevelError(resp.err))
+				require.EqualValues(t, tt.errMsg, errors.Top(resp.err))
 				return
 			}
 			require.EqualValues(t, tt.parameters.fileStatsFinal, *resp.filestats)

--- a/zboxcore/sdk/filestatsworker_test.go
+++ b/zboxcore/sdk/filestatsworker_test.go
@@ -74,7 +74,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, common.NewErrorMessage(mockErrorMessage))
+				}, common.NewError(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,

--- a/zboxcore/sdk/filestatsworker_test.go
+++ b/zboxcore/sdk/filestatsworker_test.go
@@ -93,7 +93,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 				}, nil)
 			},
 			wantErr: true,
-			errMsg:  "file stats response parse error: unexpected end of JSON input",
+			errMsg:  "file stats response parse error",
 		},
 		{
 			name: "Test_Success",
@@ -167,7 +167,7 @@ func TestListRequest_getFileStatsInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(t, tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(t, tt.errMsg, resp.err.Error())
+				require.EqualValues(t, tt.errMsg, common.TopLevelError(resp.err))
 				return
 			}
 			require.EqualValues(t, tt.parameters.fileStatsFinal, *resp.filestats)

--- a/zboxcore/sdk/listworker.go
+++ b/zboxcore/sdk/listworker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
@@ -105,7 +105,7 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapError(err, "Error: Resp")
+			return errors.WrapError(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		Logger.Debug("List result:", string(resp_body))
@@ -113,15 +113,15 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 			listResult := &fileref.ListResult{}
 			err = json.Unmarshal(resp_body, listResult)
 			if err != nil {
-				return common.WrapError(err, "list entities response parse error:")
+				return errors.WrapError(err, "list entities response parse error:")
 			}
 			ref, err = listResult.GetDirTree(req.allocationID)
 			if err != nil {
-				return common.WrapError(err, "error getting the dir tree from list response:")
+				return errors.WrapError(err, "error getting the dir tree from list response:")
 			}
 			return nil
 		} else {
-			return common.NewError(fmt.Sprintf("error from server list response: %s", s.String()))
+			return errors.NewError(fmt.Sprintf("error from server list response: %s", s.String()))
 		}
 	})
 }

--- a/zboxcore/sdk/listworker.go
+++ b/zboxcore/sdk/listworker.go
@@ -105,7 +105,7 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.WrapError(err, "Error: Resp")
+			return errors.Wrap(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		Logger.Debug("List result:", string(resp_body))
@@ -113,15 +113,15 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 			listResult := &fileref.ListResult{}
 			err = json.Unmarshal(resp_body, listResult)
 			if err != nil {
-				return errors.WrapError(err, "list entities response parse error:")
+				return errors.Wrap(err, "list entities response parse error:")
 			}
 			ref, err = listResult.GetDirTree(req.allocationID)
 			if err != nil {
-				return errors.WrapError(err, "error getting the dir tree from list response:")
+				return errors.Wrap(err, "error getting the dir tree from list response:")
 			}
 			return nil
 		} else {
-			return errors.NewError(fmt.Sprintf("error from server list response: %s", s.String()))
+			return errors.New(fmt.Sprintf("error from server list response: %s", s.String()))
 		}
 	})
 }

--- a/zboxcore/sdk/listworker.go
+++ b/zboxcore/sdk/listworker.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
@@ -104,7 +105,7 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Error: Resp : %s", err.Error())
+			return common.WrapWithMessage(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		Logger.Debug("List result:", string(resp_body))
@@ -112,15 +113,15 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 			listResult := &fileref.ListResult{}
 			err = json.Unmarshal(resp_body, listResult)
 			if err != nil {
-				return fmt.Errorf("list entities response parse error: %s", err.Error())
+				return common.WrapWithMessage(err, "list entities response parse error:")
 			}
 			ref, err = listResult.GetDirTree(req.allocationID)
 			if err != nil {
-				return fmt.Errorf("error getting the dir tree from list response: %s", err.Error())
+				return common.WrapWithMessage(err, "error getting the dir tree from list response:")
 			}
 			return nil
 		} else {
-			return fmt.Errorf("error from server list response: %s", s.String())
+			return common.NewErrorMessage(fmt.Sprintf("error from server list response: %s", s.String()))
 		}
 	})
 }

--- a/zboxcore/sdk/listworker.go
+++ b/zboxcore/sdk/listworker.go
@@ -105,7 +105,7 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 		defer resp.Body.Close()
 		resp_body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapWithMessage(err, "Error: Resp")
+			return common.WrapError(err, "Error: Resp")
 		}
 		s.WriteString(string(resp_body))
 		Logger.Debug("List result:", string(resp_body))
@@ -113,15 +113,15 @@ func (req *ListRequest) getListInfoFromBlobber(blobber *blockchain.StorageNode, 
 			listResult := &fileref.ListResult{}
 			err = json.Unmarshal(resp_body, listResult)
 			if err != nil {
-				return common.WrapWithMessage(err, "list entities response parse error:")
+				return common.WrapError(err, "list entities response parse error:")
 			}
 			ref, err = listResult.GetDirTree(req.allocationID)
 			if err != nil {
-				return common.WrapWithMessage(err, "error getting the dir tree from list response:")
+				return common.WrapError(err, "error getting the dir tree from list response:")
 			}
 			return nil
 		} else {
-			return common.NewErrorMessage(fmt.Sprintf("error from server list response: %s", s.String()))
+			return common.NewError(fmt.Sprintf("error from server list response: %s", s.String()))
 		}
 	})
 }

--- a/zboxcore/sdk/listworker_test.go
+++ b/zboxcore/sdk/listworker_test.go
@@ -80,7 +80,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, errors.NewError(mockErrorMessage))
+				}, errors.New(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,
@@ -193,7 +193,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(resp.err))
+				require.EqualValues(tt.errMsg, errors.Top(resp.err))
 				return
 			}
 			require.EqualValues(tt.parameters.listHttpResp.ref, resp.ref)

--- a/zboxcore/sdk/listworker_test.go
+++ b/zboxcore/sdk/listworker_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -80,7 +80,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, fmt.Errorf(mockErrorMessage))
+				}, common.NewErrorMessage(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,

--- a/zboxcore/sdk/listworker_test.go
+++ b/zboxcore/sdk/listworker_test.go
@@ -80,7 +80,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, common.NewErrorMessage(mockErrorMessage))
+				}, common.NewError(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,

--- a/zboxcore/sdk/listworker_test.go
+++ b/zboxcore/sdk/listworker_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -80,7 +80,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 				})).Return(&http.Response{
 					Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 					StatusCode: p.respStatusCode,
-				}, common.NewError(mockErrorMessage))
+				}, errors.NewError(mockErrorMessage))
 			},
 			wantErr: true,
 			errMsg:  mockErrorMessage,
@@ -193,7 +193,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(resp.err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(resp.err))
 				return
 			}
 			require.EqualValues(tt.parameters.listHttpResp.ref, resp.ref)

--- a/zboxcore/sdk/listworker_test.go
+++ b/zboxcore/sdk/listworker_test.go
@@ -117,7 +117,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 				}, nil)
 			},
 			wantErr: true,
-			errMsg:  "list entities response parse error: invalid character 'h' in literal true (expecting 'r')",
+			errMsg:  "list entities response parse error:",
 		},
 		{
 			name: "Test_Success",
@@ -193,7 +193,7 @@ func TestListRequest_getListInfoFromBlobber(t *testing.T) {
 			resp := <-rspCh
 			require.EqualValues(tt.wantErr, resp.err != nil)
 			if resp.err != nil {
-				require.EqualValues(tt.errMsg, resp.err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(resp.err))
 				return
 			}
 			require.EqualValues(tt.parameters.listHttpResp.ref, resp.ref)

--- a/zboxcore/sdk/networkworker.go
+++ b/zboxcore/sdk/networkworker.go
@@ -79,7 +79,7 @@ func UpdateRequired(networkDetails *Network) bool {
 func GetNetworkDetails() (*Network, error) {
 	req, ctx, cncl, err := zboxutil.NewHTTPRequest(http.MethodGet, blockchain.GetBlockWorker()+NETWORK_ENDPOINT, nil)
 	if err != nil {
-		return nil, errors.NewError("get_network_details_error", "Unable to create new http request with error "+err.Error())
+		return nil, errors.New("get_network_details_error", "Unable to create new http request with error "+err.Error())
 	}
 
 	var networkResponse Network
@@ -92,18 +92,18 @@ func GetNetworkDetails() (*Network, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.WrapError(err, "Error reading response : ")
+			return errors.Wrap(err, "Error reading response : ")
 		}
 
 		Logger.Debug("Get network result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(respBody, &networkResponse)
 			if err != nil {
-				return errors.WrapError(err, "Error unmarshaling response :")
+				return errors.Wrap(err, "Error unmarshaling response :")
 			}
 			return nil
 		}
-		return errors.NewError(strconv.Itoa(resp.StatusCode), "Get network details status not OK")
+		return errors.New(strconv.Itoa(resp.StatusCode), "Get network details status not OK")
 
 	})
 	return &networkResponse, err

--- a/zboxcore/sdk/networkworker.go
+++ b/zboxcore/sdk/networkworker.go
@@ -3,11 +3,11 @@ package sdk
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"time"
+	"strconv"
 
 	. "github.com/0chain/gosdk/zboxcore/logger"
 	"go.uber.org/zap"
@@ -92,18 +92,19 @@ func GetNetworkDetails() (*Network, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Error reading response : %s", err.Error())
+			return common.WrapWithMessage(err, "Error reading response : ")
 		}
 
 		Logger.Debug("Get network result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(respBody, &networkResponse)
 			if err != nil {
-				return fmt.Errorf("Error unmarshaling response : %s", err.Error())
+				return common.WrapWithMessage(err, "Error unmarshaling response :")
 			}
 			return nil
 		}
-		return fmt.Errorf("Get network details status not OK, Status : %v", resp.StatusCode)
+		return common.NewError(strconv.Itoa(resp.StatusCode), "Get network details status not OK")
+
 	})
 	return &networkResponse, err
 }

--- a/zboxcore/sdk/networkworker.go
+++ b/zboxcore/sdk/networkworker.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
-	"time"
 	"strconv"
+	"time"
 
 	. "github.com/0chain/gosdk/zboxcore/logger"
 	"go.uber.org/zap"
@@ -92,14 +92,14 @@ func GetNetworkDetails() (*Network, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapWithMessage(err, "Error reading response : ")
+			return common.WrapError(err, "Error reading response : ")
 		}
 
 		Logger.Debug("Get network result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(respBody, &networkResponse)
 			if err != nil {
-				return common.WrapWithMessage(err, "Error unmarshaling response :")
+				return common.WrapError(err, "Error unmarshaling response :")
 			}
 			return nil
 		}

--- a/zboxcore/sdk/networkworker.go
+++ b/zboxcore/sdk/networkworker.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/0chain/gosdk/zboxcore/logger"
 	"go.uber.org/zap"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/zboxutil"
 )
@@ -79,7 +79,7 @@ func UpdateRequired(networkDetails *Network) bool {
 func GetNetworkDetails() (*Network, error) {
 	req, ctx, cncl, err := zboxutil.NewHTTPRequest(http.MethodGet, blockchain.GetBlockWorker()+NETWORK_ENDPOINT, nil)
 	if err != nil {
-		return nil, common.NewError("get_network_details_error", "Unable to create new http request with error "+err.Error())
+		return nil, errors.NewError("get_network_details_error", "Unable to create new http request with error "+err.Error())
 	}
 
 	var networkResponse Network
@@ -92,18 +92,18 @@ func GetNetworkDetails() (*Network, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapError(err, "Error reading response : ")
+			return errors.WrapError(err, "Error reading response : ")
 		}
 
 		Logger.Debug("Get network result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(respBody, &networkResponse)
 			if err != nil {
-				return common.WrapError(err, "Error unmarshaling response :")
+				return errors.WrapError(err, "Error unmarshaling response :")
 			}
 			return nil
 		}
-		return common.NewError(strconv.Itoa(resp.StatusCode), "Get network details status not OK")
+		return errors.NewError(strconv.Itoa(resp.StatusCode), "Get network details status not OK")
 
 	})
 	return &networkResponse, err

--- a/zboxcore/sdk/renameworker.go
+++ b/zboxcore/sdk/renameworker.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"math/bits"
 	"mime/multipart"
@@ -11,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
@@ -100,7 +100,7 @@ func (req *RenameRequest) ProcessRename() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Rename failed: Rename request failed. Operation failed.")
+		return common.NewErrorMessage("Rename failed: Rename request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -144,7 +144,7 @@ func (req *RenameRequest) ProcessRename() error {
 	}
 
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Delete failed: Commit consensus failed")
+		return common.NewErrorMessage("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/renameworker.go
+++ b/zboxcore/sdk/renameworker.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
@@ -100,7 +100,7 @@ func (req *RenameRequest) ProcessRename() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return common.NewError("Rename failed: Rename request failed. Operation failed.")
+		return errors.NewError("Rename failed: Rename request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -144,7 +144,7 @@ func (req *RenameRequest) ProcessRename() error {
 	}
 
 	if !req.isConsensusOk() {
-		return common.NewError("Delete failed: Commit consensus failed")
+		return errors.NewError("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/renameworker.go
+++ b/zboxcore/sdk/renameworker.go
@@ -100,7 +100,7 @@ func (req *RenameRequest) ProcessRename() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage("Rename failed: Rename request failed. Operation failed.")
+		return common.NewError("Rename failed: Rename request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -144,7 +144,7 @@ func (req *RenameRequest) ProcessRename() error {
 	}
 
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage("Delete failed: Commit consensus failed")
+		return common.NewError("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/renameworker.go
+++ b/zboxcore/sdk/renameworker.go
@@ -100,7 +100,7 @@ func (req *RenameRequest) ProcessRename() error {
 	req.wg.Wait()
 
 	if !req.isConsensusOk() {
-		return errors.NewError("Rename failed: Rename request failed. Operation failed.")
+		return errors.New("Rename failed: Rename request failed. Operation failed.")
 	}
 
 	req.consensus = 0
@@ -144,7 +144,7 @@ func (req *RenameRequest) ProcessRename() error {
 	}
 
 	if !req.isConsensusOk() {
-		return errors.NewError("Delete failed: Commit consensus failed")
+		return errors.New("Delete failed: Commit consensus failed")
 	}
 	return nil
 }

--- a/zboxcore/sdk/renameworker_test.go
+++ b/zboxcore/sdk/renameworker_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/0chain/gosdk/core/common"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -75,7 +76,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 				}, nil)
 			},
 			wantErr: true,
-			errMsg:  "Object tree error response: Status: 400 -  ",
+			errMsg:  "400: Object tree error response: Body:  ",
 		},
 		{
 			name: "Test_Rename_Blobber_Object_Failed",
@@ -166,7 +167,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", err.Error())
+					require.EqualValues(t, "EOF", common.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -211,7 +212,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 			_, err := req.renameBlobberObject(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -402,7 +403,7 @@ func TestRenameRequest_ProcessRename(t *testing.T) {
 			err := req.ProcessRename()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, err.Error())
+				require.EqualValues(tt.errMsg, common.TopLevelError(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/renameworker_test.go
+++ b/zboxcore/sdk/renameworker_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/0chain/gosdk/core/common"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -14,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	zclient "github.com/0chain/gosdk/zboxcore/client"
@@ -167,7 +167,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", common.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.TopLevelError(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -212,7 +212,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 			_, err := req.renameBlobberObject(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -403,7 +403,7 @@ func TestRenameRequest_ProcessRename(t *testing.T) {
 			err := req.ProcessRename()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, common.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/renameworker_test.go
+++ b/zboxcore/sdk/renameworker_test.go
@@ -167,7 +167,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 						require.EqualValues(t, expected, string(actual))
 					}
 					require.Error(t, err)
-					require.EqualValues(t, "EOF", errors.TopLevelError(err))
+					require.EqualValues(t, "EOF", errors.Top(err))
 
 					return strings.HasPrefix(req.URL.Path, testName) &&
 						req.Method == "POST" &&
@@ -212,7 +212,7 @@ func TestRenameRequest_renameBlobberObject(t *testing.T) {
 			_, err := req.renameBlobberObject(req.blobbers[0], 0)
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			require.NoErrorf(err, "expected no error but got %v", err)
@@ -403,7 +403,7 @@ func TestRenameRequest_ProcessRename(t *testing.T) {
 			err := req.ProcessRename()
 			require.EqualValues(tt.wantErr, err != nil)
 			if err != nil {
-				require.EqualValues(tt.errMsg, errors.TopLevelError(err))
+				require.EqualValues(tt.errMsg, errors.Top(err))
 				return
 			}
 			if tt.wantFunc != nil {

--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -188,15 +188,15 @@ func GetReadPoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getReadPoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting read pool info")
+		return nil, common.WrapError(err, "error requesting read pool info")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapWithMessage(err, "error decoding response:")
+		return nil, common.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -332,15 +332,15 @@ func GetStakePoolInfo(blobberID string) (info *StakePoolInfo, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getStakePoolStat",
 		map[string]string{"blobber_id": blobberID}, nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting stake pool info:")
+		return nil, common.WrapError(err, "error requesting stake pool info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	info = new(StakePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapWithMessage(err, "error decoding response:")
+		return nil, common.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -365,15 +365,15 @@ func GetStakePoolUserInfo(clientID string) (info *StakePoolUserInfo, err error) 
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS,
 		"/getUserStakePoolStat", map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting stake pool user info:")
+		return nil, common.WrapError(err, "error requesting stake pool user info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	info = new(StakePoolUserInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapWithMessage(err, "error decoding response:")
+		return nil, common.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -487,15 +487,15 @@ func GetWritePoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getWritePoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting read pool info:")
+		return nil, common.WrapError(err, "error requesting read pool info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapWithMessage(err, "error decoding response:")
+		return nil, common.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -572,15 +572,15 @@ func GetChallengePoolInfo(allocID string) (info *ChallengePoolInfo, err error) {
 		"/getChallengePoolStat", map[string]string{"allocation_id": allocID},
 		nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting challenge pool info:")
+		return nil, common.WrapError(err, "error requesting challenge pool info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	info = new(ChallengePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapWithMessage(err, "error decoding response:")
+		return nil, common.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -644,19 +644,19 @@ func GetStorageSCConfig() (conf *StorageSCConfig, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getConfig", nil,
 		nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting storage SC configs:")
+		return nil, common.WrapError(err, "error requesting storage SC configs:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	conf = new(StorageSCConfig)
 	if err = json.Unmarshal(b, conf); err != nil {
-		return nil, common.WrapWithMessage(err, "rror decoding response:")
+		return nil, common.WrapError(err, "rror decoding response:")
 	}
 
 	if conf.ReadPool == nil || conf.WritePool == nil || conf.StakePool == nil {
-		return nil, common.NewErrorMessage("invalid confg: missing read/write/stake pool configs")
+		return nil, common.NewError("invalid confg: missing read/write/stake pool configs")
 	}
 	return
 }
@@ -681,10 +681,10 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getblobbers", nil,
 		nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "error requesting blobbers:")
+		return nil, common.WrapError(err, "error requesting blobbers:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response")
+		return nil, common.NewError("empty response")
 	}
 
 	type nodes struct {
@@ -694,7 +694,7 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	var wrap nodes
 
 	if err = json.Unmarshal(b, &wrap); err != nil {
-		return nil, common.WrapWithMessage(err, "error decoding response:")
+		return nil, common.WrapError(err, "error decoding response:")
 	}
 
 	return wrap.Nodes, nil
@@ -712,14 +712,14 @@ func GetBlobber(blobberID string) (blob *Blobber, err error) {
 		map[string]string{"blobber_id": blobberID},
 		nil)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "requesting blobber:")
+		return nil, common.WrapError(err, "requesting blobber:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewErrorMessage("empty response from sharders")
+		return nil, common.NewError("empty response from sharders")
 	}
 	blob = new(Blobber)
 	if err = json.Unmarshal(b, blob); err != nil {
-		return nil, common.WrapWithMessage(err, "decoding response:")
+		return nil, common.WrapError(err, "decoding response:")
 	}
 	return
 }
@@ -1111,7 +1111,7 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapWithMessage(err, "Error reading response :")
+			return common.WrapError(err, "Error reading response :")
 		}
 		Logger.Debug("Fabric commit result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {

--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/logger"
 
 	"github.com/0chain/gosdk/zboxcore/marker"
@@ -26,7 +27,7 @@ import (
 
 const STORAGE_SCADDRESS = "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7"
 
-var sdkNotInitialized = common.NewError("sdk_not_initialized", "SDK is not initialised")
+var sdkNotInitialized = errors.NewError("sdk_not_initialized", "SDK is not initialised")
 
 const (
 	OpUpload   int = 0
@@ -188,15 +189,15 @@ func GetReadPoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getReadPoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting read pool info")
+		return nil, errors.WrapError(err, "error requesting read pool info")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapError(err, "error decoding response:")
+		return nil, errors.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -332,15 +333,15 @@ func GetStakePoolInfo(blobberID string) (info *StakePoolInfo, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getStakePoolStat",
 		map[string]string{"blobber_id": blobberID}, nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting stake pool info:")
+		return nil, errors.WrapError(err, "error requesting stake pool info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	info = new(StakePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapError(err, "error decoding response:")
+		return nil, errors.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -365,15 +366,15 @@ func GetStakePoolUserInfo(clientID string) (info *StakePoolUserInfo, err error) 
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS,
 		"/getUserStakePoolStat", map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting stake pool user info:")
+		return nil, errors.WrapError(err, "error requesting stake pool user info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	info = new(StakePoolUserInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapError(err, "error decoding response:")
+		return nil, errors.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -487,15 +488,15 @@ func GetWritePoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getWritePoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting read pool info:")
+		return nil, errors.WrapError(err, "error requesting read pool info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapError(err, "error decoding response:")
+		return nil, errors.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -572,15 +573,15 @@ func GetChallengePoolInfo(allocID string) (info *ChallengePoolInfo, err error) {
 		"/getChallengePoolStat", map[string]string{"allocation_id": allocID},
 		nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting challenge pool info:")
+		return nil, errors.WrapError(err, "error requesting challenge pool info:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	info = new(ChallengePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, common.WrapError(err, "error decoding response:")
+		return nil, errors.WrapError(err, "error decoding response:")
 	}
 
 	return
@@ -644,19 +645,19 @@ func GetStorageSCConfig() (conf *StorageSCConfig, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getConfig", nil,
 		nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting storage SC configs:")
+		return nil, errors.WrapError(err, "error requesting storage SC configs:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	conf = new(StorageSCConfig)
 	if err = json.Unmarshal(b, conf); err != nil {
-		return nil, common.WrapError(err, "rror decoding response:")
+		return nil, errors.WrapError(err, "rror decoding response:")
 	}
 
 	if conf.ReadPool == nil || conf.WritePool == nil || conf.StakePool == nil {
-		return nil, common.NewError("invalid confg: missing read/write/stake pool configs")
+		return nil, errors.NewError("invalid confg: missing read/write/stake pool configs")
 	}
 	return
 }
@@ -681,10 +682,10 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getblobbers", nil,
 		nil)
 	if err != nil {
-		return nil, common.WrapError(err, "error requesting blobbers:")
+		return nil, errors.WrapError(err, "error requesting blobbers:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response")
+		return nil, errors.NewError("empty response")
 	}
 
 	type nodes struct {
@@ -694,7 +695,7 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	var wrap nodes
 
 	if err = json.Unmarshal(b, &wrap); err != nil {
-		return nil, common.WrapError(err, "error decoding response:")
+		return nil, errors.WrapError(err, "error decoding response:")
 	}
 
 	return wrap.Nodes, nil
@@ -712,14 +713,14 @@ func GetBlobber(blobberID string) (blob *Blobber, err error) {
 		map[string]string{"blobber_id": blobberID},
 		nil)
 	if err != nil {
-		return nil, common.WrapError(err, "requesting blobber:")
+		return nil, errors.WrapError(err, "requesting blobber:")
 	}
 	if len(b) == 0 {
-		return nil, common.NewError("empty response from sharders")
+		return nil, errors.NewError("empty response from sharders")
 	}
 	blob = new(Blobber)
 	if err = json.Unmarshal(b, blob); err != nil {
-		return nil, common.WrapError(err, "decoding response:")
+		return nil, errors.WrapError(err, "decoding response:")
 	}
 	return
 }
@@ -746,12 +747,12 @@ func GetAllocationFromAuthTicket(authTicket string) (*Allocation, error) {
 	}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return nil, common.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return nil, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return nil, common.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return nil, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return GetAllocation(at.AllocationID)
 }
@@ -764,12 +765,12 @@ func GetAllocation(allocationID string) (*Allocation, error) {
 	params["allocation"] = allocationID
 	allocationBytes, err := zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/allocation", params, nil)
 	if err != nil {
-		return nil, common.NewError("allocation_fetch_error", "Error fetching the allocation."+err.Error())
+		return nil, errors.NewError("allocation_fetch_error", "Error fetching the allocation."+err.Error())
 	}
 	allocationObj := &Allocation{}
 	err = json.Unmarshal(allocationBytes, allocationObj)
 	if err != nil {
-		return nil, common.NewError("allocation_decode_error", "Error decoding the allocation."+err.Error())
+		return nil, errors.NewError("allocation_decode_error", "Error decoding the allocation."+err.Error())
 	}
 	allocationObj.numBlockDownloads = numBlockDownloads
 	allocationObj.InitAllocation()
@@ -795,12 +796,12 @@ func GetAllocationsForClient(clientID string) ([]*Allocation, error) {
 	params["client"] = clientID
 	allocationsBytes, err := zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/allocations", params, nil)
 	if err != nil {
-		return nil, common.NewError("allocations_fetch_error", "Error fetching the allocations."+err.Error())
+		return nil, errors.NewError("allocations_fetch_error", "Error fetching the allocations."+err.Error())
 	}
 	allocations := make([]*Allocation, 0)
 	err = json.Unmarshal(allocationsBytes, &allocations)
 	if err != nil {
-		return nil, common.NewError("allocations_decode_error", "Error decoding the allocations."+err.Error())
+		return nil, errors.NewError("allocations_decode_error", "Error decoding the allocations."+err.Error())
 	}
 	return allocations, nil
 }
@@ -1053,7 +1054,7 @@ func smartContractTxnValueFee(sn transaction.SmartContractTxnData,
 	}
 
 	if t == nil {
-		return "", "", common.NewError("transaction_validation_failed",
+		return "", "", errors.NewError("transaction_validation_failed",
 			"Failed to get the transaction confirmation")
 	}
 
@@ -1081,7 +1082,7 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 
 	err := json.Unmarshal([]byte(fabricConfigJSON), &fabricConfig)
 	if err != nil {
-		return "", common.NewError("fabric_config_decode_error", "Unable to decode fabric config json")
+		return "", errors.NewError("fabric_config_decode_error", "Unable to decode fabric config json")
 	}
 
 	// Clear if any existing args passed
@@ -1091,12 +1092,12 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 
 	fabricData, err := json.Marshal(fabricConfig.Body)
 	if err != nil {
-		return "", common.NewError("fabric_config_encode_error", "Unable to encode fabric config body")
+		return "", errors.NewError("fabric_config_encode_error", "Unable to encode fabric config body")
 	}
 
 	req, ctx, cncl, err := zboxutil.NewHTTPRequest(http.MethodPost, fabricConfig.URL, fabricData)
 	if err != nil {
-		return "", common.NewError("fabric_commit_error", "Unable to create new http request with error "+err.Error())
+		return "", errors.NewError("fabric_commit_error", "Unable to create new http request with error "+err.Error())
 	}
 
 	// Set basic auth
@@ -1111,14 +1112,14 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return common.WrapError(err, "Error reading response :")
+			return errors.WrapError(err, "Error reading response :")
 		}
 		Logger.Debug("Fabric commit result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			fabricResponse = string(respBody)
 			return nil
 		}
-		return common.NewError(strconv.Itoa(resp.StatusCode), "Fabric commit status not OK!")
+		return errors.NewError(strconv.Itoa(resp.StatusCode), "Fabric commit status not OK!")
 	})
 	return fabricResponse, err
 }
@@ -1148,13 +1149,13 @@ func GetAllocationMinLock(datashards, parityshards int, size, expiry int64,
 	params["allocation_data"] = string(allocationData)
 	allocationsBytes, err := zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/allocation_min_lock", params, nil)
 	if err != nil {
-		return 0, common.NewError("allocation_min_lock_fetch_error", "Error fetching the allocation min lock."+err.Error())
+		return 0, errors.NewError("allocation_min_lock_fetch_error", "Error fetching the allocation min lock."+err.Error())
 	}
 
 	var response = make(map[string]int64)
 	err = json.Unmarshal(allocationsBytes, &response)
 	if err != nil {
-		return 0, common.NewError("allocation_min_lock_decode_error", "Error decoding the response."+err.Error())
+		return 0, errors.NewError("allocation_min_lock_decode_error", "Error decoding the response."+err.Error())
 	}
 	return response["min_lock_demand"], nil
 }

--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -27,7 +27,7 @@ import (
 
 const STORAGE_SCADDRESS = "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7"
 
-var sdkNotInitialized = errors.NewError("sdk_not_initialized", "SDK is not initialised")
+var sdkNotInitialized = errors.New("sdk_not_initialized", "SDK is not initialised")
 
 const (
 	OpUpload   int = 0
@@ -189,15 +189,15 @@ func GetReadPoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getReadPoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting read pool info")
+		return nil, errors.Wrap(err, "error requesting read pool info")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, errors.WrapError(err, "error decoding response:")
+		return nil, errors.Wrap(err, "error decoding response:")
 	}
 
 	return
@@ -333,15 +333,15 @@ func GetStakePoolInfo(blobberID string) (info *StakePoolInfo, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getStakePoolStat",
 		map[string]string{"blobber_id": blobberID}, nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting stake pool info:")
+		return nil, errors.Wrap(err, "error requesting stake pool info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	info = new(StakePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, errors.WrapError(err, "error decoding response:")
+		return nil, errors.Wrap(err, "error decoding response:")
 	}
 
 	return
@@ -366,15 +366,15 @@ func GetStakePoolUserInfo(clientID string) (info *StakePoolUserInfo, err error) 
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS,
 		"/getUserStakePoolStat", map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting stake pool user info:")
+		return nil, errors.Wrap(err, "error requesting stake pool user info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	info = new(StakePoolUserInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, errors.WrapError(err, "error decoding response:")
+		return nil, errors.Wrap(err, "error decoding response:")
 	}
 
 	return
@@ -488,15 +488,15 @@ func GetWritePoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getWritePoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting read pool info:")
+		return nil, errors.Wrap(err, "error requesting read pool info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, errors.WrapError(err, "error decoding response:")
+		return nil, errors.Wrap(err, "error decoding response:")
 	}
 
 	return
@@ -573,15 +573,15 @@ func GetChallengePoolInfo(allocID string) (info *ChallengePoolInfo, err error) {
 		"/getChallengePoolStat", map[string]string{"allocation_id": allocID},
 		nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting challenge pool info:")
+		return nil, errors.Wrap(err, "error requesting challenge pool info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	info = new(ChallengePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, errors.WrapError(err, "error decoding response:")
+		return nil, errors.Wrap(err, "error decoding response:")
 	}
 
 	return
@@ -645,19 +645,19 @@ func GetStorageSCConfig() (conf *StorageSCConfig, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getConfig", nil,
 		nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting storage SC configs:")
+		return nil, errors.Wrap(err, "error requesting storage SC configs:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	conf = new(StorageSCConfig)
 	if err = json.Unmarshal(b, conf); err != nil {
-		return nil, errors.WrapError(err, "rror decoding response:")
+		return nil, errors.Wrap(err, "rror decoding response:")
 	}
 
 	if conf.ReadPool == nil || conf.WritePool == nil || conf.StakePool == nil {
-		return nil, errors.NewError("invalid confg: missing read/write/stake pool configs")
+		return nil, errors.New("invalid confg: missing read/write/stake pool configs")
 	}
 	return
 }
@@ -682,10 +682,10 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getblobbers", nil,
 		nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "error requesting blobbers:")
+		return nil, errors.Wrap(err, "error requesting blobbers:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response")
+		return nil, errors.New("empty response")
 	}
 
 	type nodes struct {
@@ -695,7 +695,7 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	var wrap nodes
 
 	if err = json.Unmarshal(b, &wrap); err != nil {
-		return nil, errors.WrapError(err, "error decoding response:")
+		return nil, errors.Wrap(err, "error decoding response:")
 	}
 
 	return wrap.Nodes, nil
@@ -713,14 +713,14 @@ func GetBlobber(blobberID string) (blob *Blobber, err error) {
 		map[string]string{"blobber_id": blobberID},
 		nil)
 	if err != nil {
-		return nil, errors.WrapError(err, "requesting blobber:")
+		return nil, errors.Wrap(err, "requesting blobber:")
 	}
 	if len(b) == 0 {
-		return nil, errors.NewError("empty response from sharders")
+		return nil, errors.New("empty response from sharders")
 	}
 	blob = new(Blobber)
 	if err = json.Unmarshal(b, blob); err != nil {
-		return nil, errors.WrapError(err, "decoding response:")
+		return nil, errors.Wrap(err, "decoding response:")
 	}
 	return
 }
@@ -747,12 +747,12 @@ func GetAllocationFromAuthTicket(authTicket string) (*Allocation, error) {
 	}
 	sEnc, err := base64.StdEncoding.DecodeString(authTicket)
 	if err != nil {
-		return nil, errors.NewError("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
+		return nil, errors.New("auth_ticket_decode_error", "Error decoding the auth ticket."+err.Error())
 	}
 	at := &marker.AuthTicket{}
 	err = json.Unmarshal(sEnc, at)
 	if err != nil {
-		return nil, errors.NewError("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
+		return nil, errors.New("auth_ticket_decode_error", "Error unmarshaling the auth ticket."+err.Error())
 	}
 	return GetAllocation(at.AllocationID)
 }
@@ -765,12 +765,12 @@ func GetAllocation(allocationID string) (*Allocation, error) {
 	params["allocation"] = allocationID
 	allocationBytes, err := zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/allocation", params, nil)
 	if err != nil {
-		return nil, errors.NewError("allocation_fetch_error", "Error fetching the allocation."+err.Error())
+		return nil, errors.New("allocation_fetch_error", "Error fetching the allocation."+err.Error())
 	}
 	allocationObj := &Allocation{}
 	err = json.Unmarshal(allocationBytes, allocationObj)
 	if err != nil {
-		return nil, errors.NewError("allocation_decode_error", "Error decoding the allocation."+err.Error())
+		return nil, errors.New("allocation_decode_error", "Error decoding the allocation."+err.Error())
 	}
 	allocationObj.numBlockDownloads = numBlockDownloads
 	allocationObj.InitAllocation()
@@ -796,12 +796,12 @@ func GetAllocationsForClient(clientID string) ([]*Allocation, error) {
 	params["client"] = clientID
 	allocationsBytes, err := zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/allocations", params, nil)
 	if err != nil {
-		return nil, errors.NewError("allocations_fetch_error", "Error fetching the allocations."+err.Error())
+		return nil, errors.New("allocations_fetch_error", "Error fetching the allocations."+err.Error())
 	}
 	allocations := make([]*Allocation, 0)
 	err = json.Unmarshal(allocationsBytes, &allocations)
 	if err != nil {
-		return nil, errors.NewError("allocations_decode_error", "Error decoding the allocations."+err.Error())
+		return nil, errors.New("allocations_decode_error", "Error decoding the allocations."+err.Error())
 	}
 	return allocations, nil
 }
@@ -1054,7 +1054,7 @@ func smartContractTxnValueFee(sn transaction.SmartContractTxnData,
 	}
 
 	if t == nil {
-		return "", "", errors.NewError("transaction_validation_failed",
+		return "", "", errors.New("transaction_validation_failed",
 			"Failed to get the transaction confirmation")
 	}
 
@@ -1082,7 +1082,7 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 
 	err := json.Unmarshal([]byte(fabricConfigJSON), &fabricConfig)
 	if err != nil {
-		return "", errors.NewError("fabric_config_decode_error", "Unable to decode fabric config json")
+		return "", errors.New("fabric_config_decode_error", "Unable to decode fabric config json")
 	}
 
 	// Clear if any existing args passed
@@ -1092,12 +1092,12 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 
 	fabricData, err := json.Marshal(fabricConfig.Body)
 	if err != nil {
-		return "", errors.NewError("fabric_config_encode_error", "Unable to encode fabric config body")
+		return "", errors.New("fabric_config_encode_error", "Unable to encode fabric config body")
 	}
 
 	req, ctx, cncl, err := zboxutil.NewHTTPRequest(http.MethodPost, fabricConfig.URL, fabricData)
 	if err != nil {
-		return "", errors.NewError("fabric_commit_error", "Unable to create new http request with error "+err.Error())
+		return "", errors.New("fabric_commit_error", "Unable to create new http request with error "+err.Error())
 	}
 
 	// Set basic auth
@@ -1112,14 +1112,14 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.WrapError(err, "Error reading response :")
+			return errors.Wrap(err, "Error reading response :")
 		}
 		Logger.Debug("Fabric commit result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			fabricResponse = string(respBody)
 			return nil
 		}
-		return errors.NewError(strconv.Itoa(resp.StatusCode), "Fabric commit status not OK!")
+		return errors.New(strconv.Itoa(resp.StatusCode), "Fabric commit status not OK!")
 	})
 	return fabricResponse, err
 }
@@ -1149,13 +1149,13 @@ func GetAllocationMinLock(datashards, parityshards int, size, expiry int64,
 	params["allocation_data"] = string(allocationData)
 	allocationsBytes, err := zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/allocation_min_lock", params, nil)
 	if err != nil {
-		return 0, errors.NewError("allocation_min_lock_fetch_error", "Error fetching the allocation min lock."+err.Error())
+		return 0, errors.New("allocation_min_lock_fetch_error", "Error fetching the allocation min lock."+err.Error())
 	}
 
 	var response = make(map[string]int64)
 	err = json.Unmarshal(allocationsBytes, &response)
 	if err != nil {
-		return 0, errors.NewError("allocation_min_lock_decode_error", "Error decoding the response."+err.Error())
+		return 0, errors.New("allocation_min_lock_decode_error", "Error decoding the response."+err.Error())
 	}
 	return response["min_lock_demand"], nil
 }

--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"github.com/0chain/gosdk/core/logger"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
+
+	"github.com/0chain/gosdk/core/logger"
 
 	"github.com/0chain/gosdk/zboxcore/marker"
 
@@ -188,15 +188,15 @@ func GetReadPoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getReadPoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting read pool info: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting read pool info")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "error decoding response:")
 	}
 
 	return
@@ -332,15 +332,15 @@ func GetStakePoolInfo(blobberID string) (info *StakePoolInfo, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getStakePoolStat",
 		map[string]string{"blobber_id": blobberID}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting stake pool info: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting stake pool info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	info = new(StakePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "error decoding response:")
 	}
 
 	return
@@ -365,15 +365,15 @@ func GetStakePoolUserInfo(clientID string) (info *StakePoolUserInfo, err error) 
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS,
 		"/getUserStakePoolStat", map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting stake pool user info: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting stake pool user info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	info = new(StakePoolUserInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "error decoding response:")
 	}
 
 	return
@@ -487,15 +487,15 @@ func GetWritePoolInfo(clientID string) (info *AllocationPoolStats, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getWritePoolStat",
 		map[string]string{"client_id": clientID}, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting read pool info: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting read pool info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	info = new(AllocationPoolStats)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "error decoding response:")
 	}
 
 	return
@@ -572,15 +572,15 @@ func GetChallengePoolInfo(allocID string) (info *ChallengePoolInfo, err error) {
 		"/getChallengePoolStat", map[string]string{"allocation_id": allocID},
 		nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting challenge pool info: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting challenge pool info:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	info = new(ChallengePoolInfo)
 	if err = json.Unmarshal(b, info); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "error decoding response:")
 	}
 
 	return
@@ -644,19 +644,19 @@ func GetStorageSCConfig() (conf *StorageSCConfig, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getConfig", nil,
 		nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting storage SC configs: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting storage SC configs:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	conf = new(StorageSCConfig)
 	if err = json.Unmarshal(b, conf); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "rror decoding response:")
 	}
 
 	if conf.ReadPool == nil || conf.WritePool == nil || conf.StakePool == nil {
-		return nil, errors.New("invalid confg: missing read/write/stake pool configs")
+		return nil, common.NewErrorMessage("invalid confg: missing read/write/stake pool configs")
 	}
 	return
 }
@@ -681,10 +681,10 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	b, err = zboxutil.MakeSCRestAPICall(STORAGE_SCADDRESS, "/getblobbers", nil,
 		nil)
 	if err != nil {
-		return nil, fmt.Errorf("error requesting blobbers: %v", err)
+		return nil, common.WrapWithMessage(err, "error requesting blobbers:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response")
+		return nil, common.NewErrorMessage("empty response")
 	}
 
 	type nodes struct {
@@ -694,7 +694,7 @@ func GetBlobbers() (bs []*Blobber, err error) {
 	var wrap nodes
 
 	if err = json.Unmarshal(b, &wrap); err != nil {
-		return nil, fmt.Errorf("error decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "error decoding response:")
 	}
 
 	return wrap.Nodes, nil
@@ -712,14 +712,14 @@ func GetBlobber(blobberID string) (blob *Blobber, err error) {
 		map[string]string{"blobber_id": blobberID},
 		nil)
 	if err != nil {
-		return nil, fmt.Errorf("requesting blobber: %v", err)
+		return nil, common.WrapWithMessage(err, "requesting blobber:")
 	}
 	if len(b) == 0 {
-		return nil, errors.New("empty response from sharders")
+		return nil, common.NewErrorMessage("empty response from sharders")
 	}
 	blob = new(Blobber)
 	if err = json.Unmarshal(b, blob); err != nil {
-		return nil, fmt.Errorf("decoding response: %v", err)
+		return nil, common.WrapWithMessage(err, "decoding response:")
 	}
 	return
 }
@@ -1111,14 +1111,14 @@ func CommitToFabric(metaTxnData, fabricConfigJSON string) (string, error) {
 		defer resp.Body.Close()
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Error reading response : %s", err.Error())
+			return common.WrapWithMessage(err, "Error reading response :")
 		}
 		Logger.Debug("Fabric commit result:", string(respBody))
 		if resp.StatusCode == http.StatusOK {
 			fabricResponse = string(respBody)
 			return nil
 		}
-		return fmt.Errorf("Fabric commit status not OK, Status : %v", resp.StatusCode)
+		return common.NewError(strconv.Itoa(resp.StatusCode), "Fabric commit status not OK!")
 	})
 	return fabricResponse, err
 }

--- a/zboxcore/sdk/sharerequest.go
+++ b/zboxcore/sdk/sharerequest.go
@@ -51,7 +51,7 @@ func (req *ShareRequest) GetAuthTicketForEncryptedFile(clientID string, encPubli
 	//listReq.authToken = at
 	_, fileRef, _ = listReq.getFileConsensusFromBlobbers()
 	if fileRef == nil {
-		return "", errors.NewError("file_meta_error", "Error getting object meta data from blobbers")
+		return "", errors.New("file_meta_error", "Error getting object meta data from blobbers")
 	}
 	if fileRef.Type == fileref.DIRECTORY || len(fileRef.EncryptedKey) == 0 {
 		return req.GetAuthTicket(clientID)

--- a/zboxcore/sdk/sharerequest.go
+++ b/zboxcore/sdk/sharerequest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/client"
 	"github.com/0chain/gosdk/zboxcore/encryption"
@@ -50,7 +51,7 @@ func (req *ShareRequest) GetAuthTicketForEncryptedFile(clientID string, encPubli
 	//listReq.authToken = at
 	_, fileRef, _ = listReq.getFileConsensusFromBlobbers()
 	if fileRef == nil {
-		return "", common.NewError("file_meta_error", "Error getting object meta data from blobbers")
+		return "", errors.NewError("file_meta_error", "Error getting object meta data from blobbers")
 	}
 	if fileRef.Type == fileref.DIRECTORY || len(fileRef.EncryptedKey) == 0 {
 		return req.GetAuthTicket(clientID)

--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -275,15 +275,15 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 		fileInfo, err := os.Stat(lastSyncCachePath)
 		if err == nil {
 			if fileInfo.IsDir() {
-				return lFdiff, errors.WrapError(err, "invalid file cache.")
+				return lFdiff, errors.Wrap(err, "invalid file cache.")
 			}
 			content, err := ioutil.ReadFile(lastSyncCachePath)
 			if err != nil {
-				return lFdiff, errors.NewError("can't read cache file.")
+				return lFdiff, errors.New("can't read cache file.")
 			}
 			err = json.Unmarshal(content, &prevRemoteFileMap)
 			if err != nil {
-				return lFdiff, errors.NewError("invalid cache content.")
+				return lFdiff, errors.New("invalid cache content.")
 			}
 		}
 	}
@@ -294,14 +294,14 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 	// 3. Get flat file list from remote
 	remoteFileMap, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return lFdiff, errors.WrapError(err, "error getting list dir from remote.")
+		return lFdiff, errors.Wrap(err, "error getting list dir from remote.")
 	}
 
 	// 4. Get flat file list on the local filesystem
 	localRootPath = strings.TrimRight(localRootPath, "/")
 	localFileList, err := getLocalFileMap(localRootPath, localFileFilters, exclMap)
 	if err != nil {
-		return lFdiff, errors.WrapError(err, "error getting list dir from local.")
+		return lFdiff, errors.Wrap(err, "error getting list dir from local.")
 	}
 
 	// 5. Get the file diff with operation
@@ -318,7 +318,7 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	fileInfo, err := os.Stat(pathToSave)
 	if err == nil {
 		if fileInfo.IsDir() {
-			return errors.WrapError(err, "invalid file path to save.")
+			return errors.Wrap(err, "invalid file path to save.")
 		}
 		bIsFileExists = true
 	}
@@ -327,23 +327,23 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	exclMap := getRemoteExcludeMap(remoteExcludePath)
 	remoteFileList, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return errors.WrapError(err, "error getting list dir from remote.")
+		return errors.Wrap(err, "error getting list dir from remote.")
 	}
 
 	// Now we got the list from remote, delete the file if exists
 	if bIsFileExists {
 		err = os.Remove(pathToSave)
 		if err != nil {
-			return errors.WrapError(err, "error deleting previous cache.")
+			return errors.Wrap(err, "error deleting previous cache.")
 		}
 	}
 	by, err := json.Marshal(remoteFileList)
 	if err != nil {
-		return errors.WrapError(err, "failed to convert JSON.")
+		return errors.Wrap(err, "failed to convert JSON.")
 	}
 	err = ioutil.WriteFile(pathToSave, by, 0644)
 	if err != nil {
-		return errors.WrapError(err, "error saving file.")
+		return errors.Wrap(err, "error saving file.")
 	}
 	// Successfully saved
 	return nil

--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -275,15 +275,15 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 		fileInfo, err := os.Stat(lastSyncCachePath)
 		if err == nil {
 			if fileInfo.IsDir() {
-				return lFdiff, common.WrapWithMessage(err, "invalid file cache.")
+				return lFdiff, common.WrapError(err, "invalid file cache.")
 			}
 			content, err := ioutil.ReadFile(lastSyncCachePath)
 			if err != nil {
-				return lFdiff, common.NewErrorMessage("can't read cache file.")
+				return lFdiff, common.NewError("can't read cache file.")
 			}
 			err = json.Unmarshal(content, &prevRemoteFileMap)
 			if err != nil {
-				return lFdiff, common.NewErrorMessage("invalid cache content.")
+				return lFdiff, common.NewError("invalid cache content.")
 			}
 		}
 	}
@@ -294,14 +294,14 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 	// 3. Get flat file list from remote
 	remoteFileMap, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return lFdiff, common.WrapWithMessage(err, "error getting list dir from remote.")
+		return lFdiff, common.WrapError(err, "error getting list dir from remote.")
 	}
 
 	// 4. Get flat file list on the local filesystem
 	localRootPath = strings.TrimRight(localRootPath, "/")
 	localFileList, err := getLocalFileMap(localRootPath, localFileFilters, exclMap)
 	if err != nil {
-		return lFdiff, common.WrapWithMessage(err, "error getting list dir from local.")
+		return lFdiff, common.WrapError(err, "error getting list dir from local.")
 	}
 
 	// 5. Get the file diff with operation
@@ -318,7 +318,7 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	fileInfo, err := os.Stat(pathToSave)
 	if err == nil {
 		if fileInfo.IsDir() {
-			return common.WrapWithMessage(err, "invalid file path to save.")
+			return common.WrapError(err, "invalid file path to save.")
 		}
 		bIsFileExists = true
 	}
@@ -327,23 +327,23 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	exclMap := getRemoteExcludeMap(remoteExcludePath)
 	remoteFileList, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return common.WrapWithMessage(err, "error getting list dir from remote.")
+		return common.WrapError(err, "error getting list dir from remote.")
 	}
 
 	// Now we got the list from remote, delete the file if exists
 	if bIsFileExists {
 		err = os.Remove(pathToSave)
 		if err != nil {
-			return common.WrapWithMessage(err, "error deleting previous cache.")
+			return common.WrapError(err, "error deleting previous cache.")
 		}
 	}
 	by, err := json.Marshal(remoteFileList)
 	if err != nil {
-		return common.WrapWithMessage(err, "failed to convert JSON.")
+		return common.WrapError(err, "failed to convert JSON.")
 	}
 	err = ioutil.WriteFile(pathToSave, by, 0644)
 	if err != nil {
-		return common.WrapWithMessage(err, "error saving file.")
+		return common.WrapError(err, "error saving file.")
 	}
 	// Successfully saved
 	return nil

--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
 )
@@ -275,15 +275,15 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 		fileInfo, err := os.Stat(lastSyncCachePath)
 		if err == nil {
 			if fileInfo.IsDir() {
-				return lFdiff, common.WrapError(err, "invalid file cache.")
+				return lFdiff, errors.WrapError(err, "invalid file cache.")
 			}
 			content, err := ioutil.ReadFile(lastSyncCachePath)
 			if err != nil {
-				return lFdiff, common.NewError("can't read cache file.")
+				return lFdiff, errors.NewError("can't read cache file.")
 			}
 			err = json.Unmarshal(content, &prevRemoteFileMap)
 			if err != nil {
-				return lFdiff, common.NewError("invalid cache content.")
+				return lFdiff, errors.NewError("invalid cache content.")
 			}
 		}
 	}
@@ -294,14 +294,14 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 	// 3. Get flat file list from remote
 	remoteFileMap, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return lFdiff, common.WrapError(err, "error getting list dir from remote.")
+		return lFdiff, errors.WrapError(err, "error getting list dir from remote.")
 	}
 
 	// 4. Get flat file list on the local filesystem
 	localRootPath = strings.TrimRight(localRootPath, "/")
 	localFileList, err := getLocalFileMap(localRootPath, localFileFilters, exclMap)
 	if err != nil {
-		return lFdiff, common.WrapError(err, "error getting list dir from local.")
+		return lFdiff, errors.WrapError(err, "error getting list dir from local.")
 	}
 
 	// 5. Get the file diff with operation
@@ -318,7 +318,7 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	fileInfo, err := os.Stat(pathToSave)
 	if err == nil {
 		if fileInfo.IsDir() {
-			return common.WrapError(err, "invalid file path to save.")
+			return errors.WrapError(err, "invalid file path to save.")
 		}
 		bIsFileExists = true
 	}
@@ -327,23 +327,23 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	exclMap := getRemoteExcludeMap(remoteExcludePath)
 	remoteFileList, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return common.WrapError(err, "error getting list dir from remote.")
+		return errors.WrapError(err, "error getting list dir from remote.")
 	}
 
 	// Now we got the list from remote, delete the file if exists
 	if bIsFileExists {
 		err = os.Remove(pathToSave)
 		if err != nil {
-			return common.WrapError(err, "error deleting previous cache.")
+			return errors.WrapError(err, "error deleting previous cache.")
 		}
 	}
 	by, err := json.Marshal(remoteFileList)
 	if err != nil {
-		return common.WrapError(err, "failed to convert JSON.")
+		return errors.WrapError(err, "failed to convert JSON.")
 	}
 	err = ioutil.WriteFile(pathToSave, by, 0644)
 	if err != nil {
-		return common.WrapError(err, "error saving file.")
+		return errors.WrapError(err, "error saving file.")
 	}
 	// Successfully saved
 	return nil

--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -14,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/zboxcore/fileref"
 	. "github.com/0chain/gosdk/zboxcore/logger"
 )
@@ -275,15 +275,15 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 		fileInfo, err := os.Stat(lastSyncCachePath)
 		if err == nil {
 			if fileInfo.IsDir() {
-				return lFdiff, fmt.Errorf("invalid file cache. %v", err)
+				return lFdiff, common.WrapWithMessage(err, "invalid file cache.")
 			}
 			content, err := ioutil.ReadFile(lastSyncCachePath)
 			if err != nil {
-				return lFdiff, fmt.Errorf("can't read cache file.")
+				return lFdiff, common.NewErrorMessage("can't read cache file.")
 			}
 			err = json.Unmarshal(content, &prevRemoteFileMap)
 			if err != nil {
-				return lFdiff, fmt.Errorf("invalid cache content.")
+				return lFdiff, common.NewErrorMessage("invalid cache content.")
 			}
 		}
 	}
@@ -294,14 +294,14 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 	// 3. Get flat file list from remote
 	remoteFileMap, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return lFdiff, fmt.Errorf("error getting list dir from remote. %v", err)
+		return lFdiff, common.WrapWithMessage(err, "error getting list dir from remote.")
 	}
 
 	// 4. Get flat file list on the local filesystem
 	localRootPath = strings.TrimRight(localRootPath, "/")
 	localFileList, err := getLocalFileMap(localRootPath, localFileFilters, exclMap)
 	if err != nil {
-		return lFdiff, fmt.Errorf("error getting list dir from local. %v", err)
+		return lFdiff, common.WrapWithMessage(err, "error getting list dir from local.")
 	}
 
 	// 5. Get the file diff with operation
@@ -318,7 +318,7 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	fileInfo, err := os.Stat(pathToSave)
 	if err == nil {
 		if fileInfo.IsDir() {
-			return fmt.Errorf("invalid file path to save. %v", err)
+			return common.WrapWithMessage(err, "invalid file path to save.")
 		}
 		bIsFileExists = true
 	}
@@ -327,23 +327,23 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 	exclMap := getRemoteExcludeMap(remoteExcludePath)
 	remoteFileList, err := a.GetRemoteFileMap(exclMap)
 	if err != nil {
-		return fmt.Errorf("error getting list dir from remote. %v", err)
+		return common.WrapWithMessage(err, "error getting list dir from remote.")
 	}
 
 	// Now we got the list from remote, delete the file if exists
 	if bIsFileExists {
 		err = os.Remove(pathToSave)
 		if err != nil {
-			return fmt.Errorf("error deleting previous cache. %v", err)
+			return common.WrapWithMessage(err, "error deleting previous cache.")
 		}
 	}
 	by, err := json.Marshal(remoteFileList)
 	if err != nil {
-		return fmt.Errorf("failed to convert JSON. %v", err)
+		return common.WrapWithMessage(err, "failed to convert JSON.")
 	}
 	err = ioutil.WriteFile(pathToSave, by, 0644)
 	if err != nil {
-		return fmt.Errorf("error saving file. %v", err)
+		return common.WrapWithMessage(err, "error saving file.")
 	}
 	// Successfully saved
 	return nil

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -281,7 +281,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if resp.StatusCode != http.StatusOK {
 			Logger.Error(blobber.Baseurl, " Upload error response: ", resp.StatusCode, string(respbody))
-			req.err = errors.NewError(string(respbody))
+			req.err = errors.New(string(respbody))
 			return err
 		}
 		var r uploadResult
@@ -293,7 +293,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if r.Filename != formData.Filename || r.ShardSize != shardSize ||
 			r.Hash != formData.Hash || r.MerkleRoot != formData.MerkleRoot {
-			err = errors.NewError(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
+			err = errors.New(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
 			Logger.Error(err)
 			req.err = err
 			return err
@@ -417,7 +417,7 @@ func (req *UploadRequest) completePush() error {
 	}
 	req.wg.Wait()
 	if !req.isConsensusOk() {
-		return errors.NewError(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
+		return errors.New(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 	return nil
 }
@@ -430,19 +430,19 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 	var inFile *os.File
 	inFile, err := os.Open(req.filepath)
 	if err != nil && req.statusCallback != nil {
-		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("open_file_failed", err.Error()))
+		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.New("open_file_failed", err.Error()))
 		return
 	}
 	defer inFile.Close()
 	mimetype, err := zboxutil.GetFileContentType(inFile)
 	if err != nil && req.statusCallback != nil {
-		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("mime_type_error", err.Error()))
+		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.New("mime_type_error", err.Error()))
 		return
 	}
 	req.filemeta.MimeType = mimetype
 	err = req.setupUpload(a)
 	if err != nil && req.statusCallback != nil {
-		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("setup_upload_failed", err.Error()))
+		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.New("setup_upload_failed", err.Error()))
 		return
 	}
 	size := req.filemeta.Size
@@ -476,7 +476,7 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 			b1 := make([]byte, remaining*int64(a.DataShards))
 			_, err = dataReader.Read(b1)
 			if err != nil && req.statusCallback != nil {
-				req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("read_failed", err.Error()))
+				req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.New("read_failed", err.Error()))
 				return
 			}
 			if req.isUploadCanceled {
@@ -485,13 +485,13 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 					go a.DeleteFile(req.remotefilepath)
 				}
 				if req.statusCallback != nil {
-					req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("user_aborted", "Upload aborted by user"))
+					req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.New("user_aborted", "Upload aborted by user"))
 				}
 				return
 			}
 			err = req.pushData(b1)
 			if err != nil {
-				req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("push_error", err.Error()))
+				req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.New("push_error", err.Error()))
 				return
 			}
 
@@ -601,7 +601,7 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 			a.deleteFile(req.remotefilepath, req.consensus, req.consensus)
 		}
 		if req.statusCallback != nil {
-			req.statusCallback.Error(a.ID, req.remotefilepath, OpUpload, errors.NewError("commit_consensus_failed", "Upload failed as there was no commit consensus"))
+			req.statusCallback.Error(a.ID, req.remotefilepath, OpUpload, errors.New("commit_consensus_failed", "Upload failed as there was no commit consensus"))
 			return
 		}
 	}

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -281,7 +281,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if resp.StatusCode != http.StatusOK {
 			Logger.Error(blobber.Baseurl, " Upload error response: ", resp.StatusCode, string(respbody))
-			req.err = fmt.Errorf(string(respbody))
+			req.err = common.NewErrorMessage(string(respbody))
 			return err
 		}
 		var r uploadResult
@@ -293,7 +293,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if r.Filename != formData.Filename || r.ShardSize != shardSize ||
 			r.Hash != formData.Hash || r.MerkleRoot != formData.MerkleRoot {
-			err = fmt.Errorf(blobber.Baseurl, "Unexpected upload response data", string(respbody))
+			err = common.NewErrorMessage(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
 			Logger.Error(err)
 			req.err = err
 			return err
@@ -417,7 +417,7 @@ func (req *UploadRequest) completePush() error {
 	}
 	req.wg.Wait()
 	if !req.isConsensusOk() {
-		return fmt.Errorf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk())
+		return common.NewErrorMessage(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 	return nil
 }

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/zboxcore/allocationchange"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -281,7 +281,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if resp.StatusCode != http.StatusOK {
 			Logger.Error(blobber.Baseurl, " Upload error response: ", resp.StatusCode, string(respbody))
-			req.err = common.NewError(string(respbody))
+			req.err = errors.NewError(string(respbody))
 			return err
 		}
 		var r uploadResult
@@ -293,7 +293,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if r.Filename != formData.Filename || r.ShardSize != shardSize ||
 			r.Hash != formData.Hash || r.MerkleRoot != formData.MerkleRoot {
-			err = common.NewError(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
+			err = errors.NewError(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
 			Logger.Error(err)
 			req.err = err
 			return err
@@ -417,7 +417,7 @@ func (req *UploadRequest) completePush() error {
 	}
 	req.wg.Wait()
 	if !req.isConsensusOk() {
-		return common.NewError(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
+		return errors.NewError(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 	return nil
 }
@@ -430,19 +430,19 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 	var inFile *os.File
 	inFile, err := os.Open(req.filepath)
 	if err != nil && req.statusCallback != nil {
-		req.statusCallback.Error(a.ID, req.filepath, OpUpload, common.NewError("open_file_failed", err.Error()))
+		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("open_file_failed", err.Error()))
 		return
 	}
 	defer inFile.Close()
 	mimetype, err := zboxutil.GetFileContentType(inFile)
 	if err != nil && req.statusCallback != nil {
-		req.statusCallback.Error(a.ID, req.filepath, OpUpload, common.NewError("mime_type_error", err.Error()))
+		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("mime_type_error", err.Error()))
 		return
 	}
 	req.filemeta.MimeType = mimetype
 	err = req.setupUpload(a)
 	if err != nil && req.statusCallback != nil {
-		req.statusCallback.Error(a.ID, req.filepath, OpUpload, common.NewError("setup_upload_failed", err.Error()))
+		req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("setup_upload_failed", err.Error()))
 		return
 	}
 	size := req.filemeta.Size
@@ -476,7 +476,7 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 			b1 := make([]byte, remaining*int64(a.DataShards))
 			_, err = dataReader.Read(b1)
 			if err != nil && req.statusCallback != nil {
-				req.statusCallback.Error(a.ID, req.filepath, OpUpload, common.NewError("read_failed", err.Error()))
+				req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("read_failed", err.Error()))
 				return
 			}
 			if req.isUploadCanceled {
@@ -485,13 +485,13 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 					go a.DeleteFile(req.remotefilepath)
 				}
 				if req.statusCallback != nil {
-					req.statusCallback.Error(a.ID, req.filepath, OpUpload, common.NewError("user_aborted", "Upload aborted by user"))
+					req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("user_aborted", "Upload aborted by user"))
 				}
 				return
 			}
 			err = req.pushData(b1)
 			if err != nil {
-				req.statusCallback.Error(a.ID, req.filepath, OpUpload, common.NewError("push_error", err.Error()))
+				req.statusCallback.Error(a.ID, req.filepath, OpUpload, errors.NewError("push_error", err.Error()))
 				return
 			}
 
@@ -601,7 +601,7 @@ func (req *UploadRequest) processUpload(ctx context.Context, a *Allocation) {
 			a.deleteFile(req.remotefilepath, req.consensus, req.consensus)
 		}
 		if req.statusCallback != nil {
-			req.statusCallback.Error(a.ID, req.remotefilepath, OpUpload, common.NewError("commit_consensus_failed", "Upload failed as there was no commit consensus"))
+			req.statusCallback.Error(a.ID, req.remotefilepath, OpUpload, errors.NewError("commit_consensus_failed", "Upload failed as there was no commit consensus"))
 			return
 		}
 	}

--- a/zboxcore/sdk/uploadworker.go
+++ b/zboxcore/sdk/uploadworker.go
@@ -281,7 +281,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if resp.StatusCode != http.StatusOK {
 			Logger.Error(blobber.Baseurl, " Upload error response: ", resp.StatusCode, string(respbody))
-			req.err = common.NewErrorMessage(string(respbody))
+			req.err = common.NewError(string(respbody))
 			return err
 		}
 		var r uploadResult
@@ -293,7 +293,7 @@ func (req *UploadRequest) prepareUpload(a *Allocation, blobber *blockchain.Stora
 		}
 		if r.Filename != formData.Filename || r.ShardSize != shardSize ||
 			r.Hash != formData.Hash || r.MerkleRoot != formData.MerkleRoot {
-			err = common.NewErrorMessage(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
+			err = common.NewError(fmt.Sprintf(blobber.Baseurl, "Unexpected upload response data", string(respbody)))
 			Logger.Error(err)
 			req.err = err
 			return err
@@ -417,7 +417,7 @@ func (req *UploadRequest) completePush() error {
 	}
 	req.wg.Wait()
 	if !req.isConsensusOk() {
-		return common.NewErrorMessage(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
+		return common.NewError(fmt.Sprintf("Upload failed: Consensus_rate:%f, expected:%f", req.getConsensusRate(), req.getConsensusRequiredForOk()))
 	}
 	return nil
 }

--- a/zboxcore/zboxutil/http.go
+++ b/zboxcore/zboxutil/http.go
@@ -488,7 +488,7 @@ func MakeSCRestAPICall(scAddress string, relativePath string, params map[string]
 	var err error
 	rate := maxCount * 100 / float32(numSharders)
 	if rate < consensusThresh {
-		err = errors.NewError("consensus_failed", "consensus failed on sharders")
+		err = errors.New("consensus_failed", "consensus failed on sharders")
 	}
 
 	if handler != nil {

--- a/zboxcore/zboxutil/http.go
+++ b/zboxcore/zboxutil/http.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -488,7 +488,7 @@ func MakeSCRestAPICall(scAddress string, relativePath string, params map[string]
 	var err error
 	rate := maxCount * 100 / float32(numSharders)
 	if rate < consensusThresh {
-		err = common.NewError("consensus_failed", "consensus failed on sharders")
+		err = errors.NewError("consensus_failed", "consensus failed on sharders")
 	}
 
 	if handler != nil {

--- a/zboxcore/zboxutil/util.go
+++ b/zboxcore/zboxutil/util.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -13,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/0chain/gosdk/core/common"
 
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -186,7 +187,7 @@ func Decrypt(key, text []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(text) < aes.BlockSize {
-		return nil, errors.New("ciphertext too short")
+		return nil, common.NewErrorMessage("ciphertext too short")
 	}
 	iv := text[:aes.BlockSize]
 	text = text[aes.BlockSize:]

--- a/zboxcore/zboxutil/util.go
+++ b/zboxcore/zboxutil/util.go
@@ -186,7 +186,7 @@ func Decrypt(key, text []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(text) < aes.BlockSize {
-		return nil, errors.NewError("ciphertext too short")
+		return nil, errors.New("ciphertext too short")
 	}
 	iv := text[:aes.BlockSize]
 	text = text[aes.BlockSize:]

--- a/zboxcore/zboxutil/util.go
+++ b/zboxcore/zboxutil/util.go
@@ -13,8 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/0chain/gosdk/core/common"
-
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/h2non/filetype"
@@ -187,7 +186,7 @@ func Decrypt(key, text []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(text) < aes.BlockSize {
-		return nil, common.NewError("ciphertext too short")
+		return nil, errors.NewError("ciphertext too short")
 	}
 	iv := text[:aes.BlockSize]
 	text = text[aes.BlockSize:]

--- a/zboxcore/zboxutil/util.go
+++ b/zboxcore/zboxutil/util.go
@@ -187,7 +187,7 @@ func Decrypt(key, text []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(text) < aes.BlockSize {
-		return nil, common.NewErrorMessage("ciphertext too short")
+		return nil, common.NewError("ciphertext too short")
 	}
 	iv := text[:aes.BlockSize]
 	text = text[aes.BlockSize:]

--- a/zcncore/mswallet.go
+++ b/zcncore/mswallet.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/core/zcncrypto"
 )
@@ -56,7 +56,7 @@ type MSTransfer struct {
 func (msw *MSWallet) Marshal() (string, error) {
 	msws, err := json.Marshal(msw)
 	if err != nil {
-		return "", common.NewError("Invalid Wallet")
+		return "", errors.NewError("Invalid Wallet")
 	}
 	return string(msws), nil
 }
@@ -70,7 +70,7 @@ type MSVoteCallback interface {
 func CreateMSWallet(t, n int) (string, string, []string, error) {
 	id := 0
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", "", nil, common.NewError("encryption scheme for this blockchain is not bls0chain")
+		return "", "", nil, errors.NewError("encryption scheme for this blockchain is not bls0chain")
 
 	}
 
@@ -87,7 +87,7 @@ func CreateMSWallet(t, n int) (string, string, []string, error) {
 	signerKeys, err := zcncrypto.BLS0GenerateThresholdKeyShares(t, n, groupKey)
 
 	if err != nil {
-		return "", "", nil, common.WrapError(err, "Err in generateThresholdKeyShares")
+		return "", "", nil, errors.WrapError(err, "Err in generateThresholdKeyShares")
 	}
 	var signerClientIDs []string
 	for _, key := range signerKeys {
@@ -141,11 +141,11 @@ func RegisterWallet(walletString string, cb WalletCallback) {
 func CreateMSVote(proposal, grpClientID, signerWalletstr, toClientID string, token int64) (string, error) {
 
 	if proposal == "" || grpClientID == "" || toClientID == "" || signerWalletstr == "" {
-		return "", common.NewError("proposal or groupClient or signer wallet or toClientID cannot be empty")
+		return "", errors.NewError("proposal or groupClient or signer wallet or toClientID cannot be empty")
 	}
 
 	if token < 1 {
-		return "", common.NewError("Token cannot be less than 1")
+		return "", errors.NewError("Token cannot be less than 1")
 	}
 
 	signerWallet, err := GetWallet(signerWalletstr)

--- a/zcncore/mswallet.go
+++ b/zcncore/mswallet.go
@@ -56,7 +56,7 @@ type MSTransfer struct {
 func (msw *MSWallet) Marshal() (string, error) {
 	msws, err := json.Marshal(msw)
 	if err != nil {
-		return "", errors.NewError("Invalid Wallet")
+		return "", errors.New("Invalid Wallet")
 	}
 	return string(msws), nil
 }
@@ -70,7 +70,7 @@ type MSVoteCallback interface {
 func CreateMSWallet(t, n int) (string, string, []string, error) {
 	id := 0
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", "", nil, errors.NewError("encryption scheme for this blockchain is not bls0chain")
+		return "", "", nil, errors.New("encryption scheme for this blockchain is not bls0chain")
 
 	}
 
@@ -87,7 +87,7 @@ func CreateMSWallet(t, n int) (string, string, []string, error) {
 	signerKeys, err := zcncrypto.BLS0GenerateThresholdKeyShares(t, n, groupKey)
 
 	if err != nil {
-		return "", "", nil, errors.WrapError(err, "Err in generateThresholdKeyShares")
+		return "", "", nil, errors.Wrap(err, "Err in generateThresholdKeyShares")
 	}
 	var signerClientIDs []string
 	for _, key := range signerKeys {
@@ -141,11 +141,11 @@ func RegisterWallet(walletString string, cb WalletCallback) {
 func CreateMSVote(proposal, grpClientID, signerWalletstr, toClientID string, token int64) (string, error) {
 
 	if proposal == "" || grpClientID == "" || toClientID == "" || signerWalletstr == "" {
-		return "", errors.NewError("proposal or groupClient or signer wallet or toClientID cannot be empty")
+		return "", errors.New("proposal or groupClient or signer wallet or toClientID cannot be empty")
 	}
 
 	if token < 1 {
-		return "", errors.NewError("Token cannot be less than 1")
+		return "", errors.New("Token cannot be less than 1")
 	}
 
 	signerWallet, err := GetWallet(signerWalletstr)

--- a/zcncore/mswallet.go
+++ b/zcncore/mswallet.go
@@ -56,7 +56,7 @@ type MSTransfer struct {
 func (msw *MSWallet) Marshal() (string, error) {
 	msws, err := json.Marshal(msw)
 	if err != nil {
-		return "", common.NewErrorMessage("Invalid Wallet")
+		return "", common.NewError("Invalid Wallet")
 	}
 	return string(msws), nil
 }
@@ -70,7 +70,7 @@ type MSVoteCallback interface {
 func CreateMSWallet(t, n int) (string, string, []string, error) {
 	id := 0
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", "", nil, common.NewErrorMessage("encryption scheme for this blockchain is not bls0chain")
+		return "", "", nil, common.NewError("encryption scheme for this blockchain is not bls0chain")
 
 	}
 
@@ -87,7 +87,7 @@ func CreateMSWallet(t, n int) (string, string, []string, error) {
 	signerKeys, err := zcncrypto.BLS0GenerateThresholdKeyShares(t, n, groupKey)
 
 	if err != nil {
-		return "", "", nil, common.WrapWithMessage(err, "Err in generateThresholdKeyShares")
+		return "", "", nil, common.WrapError(err, "Err in generateThresholdKeyShares")
 	}
 	var signerClientIDs []string
 	for _, key := range signerKeys {
@@ -141,11 +141,11 @@ func RegisterWallet(walletString string, cb WalletCallback) {
 func CreateMSVote(proposal, grpClientID, signerWalletstr, toClientID string, token int64) (string, error) {
 
 	if proposal == "" || grpClientID == "" || toClientID == "" || signerWalletstr == "" {
-		return "", common.NewErrorMessage("proposal or groupClient or signer wallet or toClientID cannot be empty")
+		return "", common.NewError("proposal or groupClient or signer wallet or toClientID cannot be empty")
 	}
 
 	if token < 1 {
-		return "", common.NewErrorMessage("Token cannot be less than 1")
+		return "", common.NewError("Token cannot be less than 1")
 	}
 
 	signerWallet, err := GetWallet(signerWalletstr)

--- a/zcncore/mswallet.go
+++ b/zcncore/mswallet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/core/zcncrypto"
 )
@@ -55,7 +56,7 @@ type MSTransfer struct {
 func (msw *MSWallet) Marshal() (string, error) {
 	msws, err := json.Marshal(msw)
 	if err != nil {
-		return "", fmt.Errorf("Invalid Wallet")
+		return "", common.NewErrorMessage("Invalid Wallet")
 	}
 	return string(msws), nil
 }
@@ -69,14 +70,14 @@ type MSVoteCallback interface {
 func CreateMSWallet(t, n int) (string, string, []string, error) {
 	id := 0
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", "", nil, fmt.Errorf("encryption scheme for this blockchain is not bls0chain")
+		return "", "", nil, common.NewErrorMessage("encryption scheme for this blockchain is not bls0chain")
 
 	}
 
 	groupKey := zcncrypto.NewBLS0ChainScheme()
 	wallet, err := groupKey.GenerateKeys()
 	if err != nil {
-		return "", "", nil, fmt.Errorf("%s", err.Error())
+		return "", "", nil, err
 	}
 
 	Logger.Info(fmt.Sprintf("Wallet id: %s", wallet.ClientKey))
@@ -86,7 +87,7 @@ func CreateMSWallet(t, n int) (string, string, []string, error) {
 	signerKeys, err := zcncrypto.BLS0GenerateThresholdKeyShares(t, n, groupKey)
 
 	if err != nil {
-		return "", "", nil, fmt.Errorf("Err in generateThresholdKeyShares %s", err.Error())
+		return "", "", nil, common.WrapWithMessage(err, "Err in generateThresholdKeyShares")
 	}
 	var signerClientIDs []string
 	for _, key := range signerKeys {
@@ -140,11 +141,11 @@ func RegisterWallet(walletString string, cb WalletCallback) {
 func CreateMSVote(proposal, grpClientID, signerWalletstr, toClientID string, token int64) (string, error) {
 
 	if proposal == "" || grpClientID == "" || toClientID == "" || signerWalletstr == "" {
-		return "", fmt.Errorf("proposal or groupClient or signer wallet or toClientID cannot be empty")
+		return "", common.NewErrorMessage("proposal or groupClient or signer wallet or toClientID cannot be empty")
 	}
 
 	if token < 1 {
-		return "", fmt.Errorf("Token cannot be less than 1")
+		return "", common.NewErrorMessage("Token cannot be less than 1")
 	}
 
 	signerWallet, err := GetWallet(signerWalletstr)

--- a/zcncore/networkworker.go
+++ b/zcncore/networkworker.go
@@ -86,7 +86,7 @@ func GetNetworkDetails() (*Network, error) {
 	var networkResponse Network
 	err = json.Unmarshal([]byte(res.Body), &networkResponse)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "Error unmarshaling response :")
+		return nil, common.WrapError(err, "Error unmarshaling response :")
 	}
 	return &networkResponse, nil
 

--- a/zcncore/networkworker.go
+++ b/zcncore/networkworker.go
@@ -3,7 +3,6 @@ package zcncore
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -87,7 +86,7 @@ func GetNetworkDetails() (*Network, error) {
 	var networkResponse Network
 	err = json.Unmarshal([]byte(res.Body), &networkResponse)
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshaling response : %s", err.Error())
+		return nil, common.WrapWithMessage(err, "Error unmarshaling response :")
 	}
 	return &networkResponse, nil
 

--- a/zcncore/networkworker.go
+++ b/zcncore/networkworker.go
@@ -75,18 +75,18 @@ func UpdateRequired(networkDetails *Network) bool {
 func GetNetworkDetails() (*Network, error) {
 	req, err := util.NewHTTPGetRequest(_config.chain.BlockWorker + NETWORK_ENDPOINT)
 	if err != nil {
-		return nil, errors.NewError("get_network_details_error", "Unable to create new http request with error "+err.Error())
+		return nil, errors.New("get_network_details_error", "Unable to create new http request with error "+err.Error())
 	}
 
 	res, err := req.Get()
 	if err != nil {
-		return nil, errors.NewError("get_network_details_error", "Unable to get http request with error "+err.Error())
+		return nil, errors.New("get_network_details_error", "Unable to get http request with error "+err.Error())
 	}
 
 	var networkResponse Network
 	err = json.Unmarshal([]byte(res.Body), &networkResponse)
 	if err != nil {
-		return nil, errors.WrapError(err, "Error unmarshaling response :")
+		return nil, errors.Wrap(err, "Error unmarshaling response :")
 	}
 	return &networkResponse, nil
 

--- a/zcncore/networkworker.go
+++ b/zcncore/networkworker.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/util"
 	"go.uber.org/zap"
 )
@@ -75,18 +75,18 @@ func UpdateRequired(networkDetails *Network) bool {
 func GetNetworkDetails() (*Network, error) {
 	req, err := util.NewHTTPGetRequest(_config.chain.BlockWorker + NETWORK_ENDPOINT)
 	if err != nil {
-		return nil, common.NewError("get_network_details_error", "Unable to create new http request with error "+err.Error())
+		return nil, errors.NewError("get_network_details_error", "Unable to create new http request with error "+err.Error())
 	}
 
 	res, err := req.Get()
 	if err != nil {
-		return nil, common.NewError("get_network_details_error", "Unable to get http request with error "+err.Error())
+		return nil, errors.NewError("get_network_details_error", "Unable to get http request with error "+err.Error())
 	}
 
 	var networkResponse Network
 	err = json.Unmarshal([]byte(res.Body), &networkResponse)
 	if err != nil {
-		return nil, common.WrapError(err, "Error unmarshaling response :")
+		return nil, errors.WrapError(err, "Error unmarshaling response :")
 	}
 	return &networkResponse, nil
 

--- a/zcncore/transaction.go
+++ b/zcncore/transaction.go
@@ -24,11 +24,11 @@ var (
 )
 
 var (
-	errNetwork          = common.NewErrorMessage("network error. host not reachable")
-	errUserRejected     = common.NewErrorMessage("rejected by user")
-	errAuthVerifyFailed = common.NewErrorMessage("verfication failed for auth response")
-	errAuthTimeout      = common.NewErrorMessage("auth timed out")
-	errAddSignature     = common.NewErrorMessage("error adding signature")
+	errNetwork          = common.NewError("network error. host not reachable")
+	errUserRejected     = common.NewError("rejected by user")
+	errAuthVerifyFailed = common.NewError("verfication failed for auth response")
+	errAuthTimeout      = common.NewError("auth timed out")
+	errAddSignature     = common.NewError("error adding signature")
 )
 
 // TransactionCallback needs to be implemented by the caller for transaction related APIs
@@ -162,7 +162,7 @@ func signWithWallet(hash string, wi interface{}) (string, error) {
 
 	if !ok {
 		fmt.Printf("Error in casting to wallet")
-		return "", common.NewErrorMessage("error in casting to wallet")
+		return "", common.NewError("error in casting to wallet")
 	}
 	sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
 	sigScheme.SetPrivateKey(w.Keys[0].PrivateKey)
@@ -259,7 +259,7 @@ func (t *Transaction) submitTxn() {
 	}
 	rate := consensus * 100 / float32(len(randomMiners))
 	if rate < consensusThresh {
-		t.completeTxn(StatusError, "", common.NewErrorMessage(fmt.Sprintf("submit transaction failed. %s", tFailureRsp)))
+		t.completeTxn(StatusError, "", common.NewError(fmt.Sprintf("submit transaction failed. %s", tFailureRsp)))
 		return
 	}
 	time.Sleep(3 * time.Second)
@@ -283,7 +283,7 @@ func NewTransaction(cb TransactionCallback, txnFee int64) (TransactionScheme, er
 	}
 	if _config.isSplitWallet {
 		if _config.authUrl == "" {
-			return nil, common.NewErrorMessage("auth url not set")
+			return nil, common.NewError("auth url not set")
 		}
 		Logger.Info("New transaction interface with auth")
 		return newTransactionWithAuth(cb, txnFee)
@@ -294,7 +294,7 @@ func NewTransaction(cb TransactionCallback, txnFee int64) (TransactionScheme, er
 
 func (t *Transaction) SetTransactionCallback(cb TransactionCallback) error {
 	if t.txnStatus != StatusUnknown {
-		return common.NewErrorMessage("transaction already exists. cannot set transaction hash.")
+		return common.NewError("transaction already exists. cannot set transaction hash.")
 	}
 	t.txnCb = cb
 	return nil
@@ -302,7 +302,7 @@ func (t *Transaction) SetTransactionCallback(cb TransactionCallback) error {
 
 func (t *Transaction) SetTransactionFee(txnFee int64) error {
 	if t.txnStatus != StatusUnknown {
-		return common.NewErrorMessage("transaction already exists. cannot set transaction fee.")
+		return common.NewError("transaction already exists. cannot set transaction fee.")
 	}
 	t.txn.TransactionFee = txnFee
 	return nil
@@ -346,7 +346,7 @@ func (t *Transaction) createSmartContractTxn(address, methodName string, input i
 	sn := transaction.SmartContractTxnData{Name: methodName, InputArgs: input}
 	snBytes, err := json.Marshal(sn)
 	if err != nil {
-		return common.WrapWithMessage(err, "create smart contract failed due to invalid data.")
+		return common.WrapError(err, "create smart contract failed due to invalid data.")
 	}
 	t.txn.TransactionType = transaction.TxnTypeSmartContract
 	t.txn.ToClientID = address
@@ -397,7 +397,7 @@ func (t *Transaction) ExecuteSmartContract(address, methodName, jsoninput string
 
 func (t *Transaction) SetTransactionHash(hash string) error {
 	if t.txnStatus != StatusUnknown {
-		return common.NewErrorMessage("transaction already exists. cannot set transaction hash.")
+		return common.NewError("transaction already exists. cannot set transaction hash.")
 	}
 	t.txnHash = hash
 	return nil
@@ -461,20 +461,20 @@ func getBlockHeaderFromTransactionConfirmation(txnHash string, cfmBlock map[stri
 		var cfm confirmation
 		err := json.Unmarshal(cfmBytes, &cfm)
 		if err != nil {
-			return nil, common.WrapWithMessage(err, "txn confirmation parse error.")
+			return nil, common.WrapError(err, "txn confirmation parse error.")
 		}
 		if cfm.Transaction == nil {
-			return nil, common.NewErrorMessage(fmt.Sprintf("missing transaction %s in block confirmation", txnHash))
+			return nil, common.NewError(fmt.Sprintf("missing transaction %s in block confirmation", txnHash))
 		}
 		if txnHash != cfm.Transaction.Hash {
-			return nil, common.NewErrorMessage(fmt.Sprintf("invalid transaction hash. Expected: %s. Received: %s", txnHash, cfm.Transaction.Hash))
+			return nil, common.NewError(fmt.Sprintf("invalid transaction hash. Expected: %s. Received: %s", txnHash, cfm.Transaction.Hash))
 		}
 		if !util.VerifyMerklePath(cfm.Transaction.Hash, cfm.MerkleTreePath, cfm.MerkleTreeRoot) {
-			return nil, common.NewErrorMessage("txn merkle validation failed.")
+			return nil, common.NewError("txn merkle validation failed.")
 		}
 		txnRcpt := transaction.NewTransactionReceipt(cfm.Transaction)
 		if !util.VerifyMerklePath(txnRcpt.GetHash(), cfm.ReceiptMerkleTreePath, cfm.ReceiptMerkleTreeRoot) {
-			return nil, common.NewErrorMessage("txn receipt cmerkle validation failed.")
+			return nil, common.NewError("txn receipt cmerkle validation failed.")
 		}
 		prevBlockHash := cfm.PreviousBlockHash
 		block.MinerId = cfm.MinerID
@@ -488,10 +488,10 @@ func getBlockHeaderFromTransactionConfirmation(txnHash string, cfmBlock map[stri
 		if isBlockExtends(prevBlockHash, block) {
 			return block, nil
 		} else {
-			return nil, common.NewErrorMessage("block hash verification failed in confirmation")
+			return nil, common.NewError("block hash verification failed in confirmation")
 		}
 	}
-	return nil, common.NewErrorMessage("txn confirmation not found.")
+	return nil, common.NewError("txn confirmation not found.")
 }
 
 func getTransactionConfirmation(numSharders int, txnHash string) (*blockHeader, map[string]json.RawMessage, *blockHeader, error) {
@@ -539,7 +539,7 @@ func getTransactionConfirmation(numSharders int, txnHash string) (*blockHeader, 
 		}
 	}
 	if maxConfirmation == 0 {
-		return nil, confirmation, &lfb, common.NewErrorMessage("transaction not found")
+		return nil, confirmation, &lfb, common.NewError("transaction not found")
 	}
 	return blockHdr, confirmation, &lfb, nil
 }
@@ -579,7 +579,7 @@ func GetLatestFinalized(ctx context.Context, numSharders int) (b *block.Header, 
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewErrorMessage("block info not found")
+		return nil, common.NewError("block info not found")
 	}
 
 	return
@@ -626,7 +626,7 @@ func GetLatestFinalizedMagicBlock(ctx context.Context, numSharders int) (m *bloc
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewErrorMessage("magic block info not found")
+		return nil, common.NewError("magic block info not found")
 	}
 
 	return
@@ -719,7 +719,7 @@ func GetBlockByRound(ctx context.Context, numSharders int, round int64) (b *bloc
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewErrorMessage("round info not found")
+		return nil, common.NewError("round info not found")
 	}
 
 	return
@@ -769,7 +769,7 @@ func GetMagicBlockByNumber(ctx context.Context, numSharders int, number int64) (
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewErrorMessage("magic block info not found")
+		return nil, common.NewError("magic block info not found")
 	}
 
 	return
@@ -821,7 +821,7 @@ func getBlockInfoByRound(numSharders int, round int64, content string) (*blockHe
 		}
 	}
 	if maxConsensus == 0 {
-		return nil, common.NewErrorMessage("round info not found.")
+		return nil, common.NewError("round info not found.")
 	}
 	return &blkHdr, nil
 }
@@ -882,12 +882,12 @@ func (t *Transaction) isTransactionExpired(lfbCreationTime, currentTime int64) b
 }
 func (t *Transaction) Verify() error {
 	if t.txnHash == "" && t.txnStatus == StatusUnknown {
-		return common.NewErrorMessage("invalid transaction. cannot be verified.")
+		return common.NewError("invalid transaction. cannot be verified.")
 	}
 	if t.txnHash == "" && t.txnStatus == StatusSuccess {
 		h := t.GetTransactionHash()
 		if h == "" {
-			return common.NewErrorMessage("invalid transaction. cannot be verified.")
+			return common.NewError("invalid transaction. cannot be verified.")
 		}
 	}
 	// If transaction is verify only start from current time
@@ -907,14 +907,14 @@ func (t *Transaction) Verify() error {
 					confirmBlock, confirmation, lfb, err = getTransactionConfirmation(getMinShardersVerify(), t.txnHash)
 					if err != nil {
 						if t.isTransactionExpired(lfb.CreationDate, tn) {
-							t.completeVerify(StatusError, "", common.NewErrorMessage(`{"error": "verify transaction failed"}`))
+							t.completeVerify(StatusError, "", common.NewError(`{"error": "verify transaction failed"}`))
 							return
 						}
 						continue
 					}
 				} else {
 					if t.isTransactionExpired(lfb.CreationDate, tn) {
-						t.completeVerify(StatusError, "", common.NewErrorMessage(`{"error": "verify transaction failed"}`))
+						t.completeVerify(StatusError, "", common.NewError(`{"error": "verify transaction failed"}`))
 						return
 					}
 					continue
@@ -924,7 +924,7 @@ func (t *Transaction) Verify() error {
 			if valid {
 				output, err := json.Marshal(confirmation)
 				if err != nil {
-					t.completeVerify(StatusError, "", common.NewErrorMessage(`{"error": "transaction confirmation json marshal error"`))
+					t.completeVerify(StatusError, "", common.NewError(`{"error": "transaction confirmation json marshal error"`))
 					return
 				}
 				t.completeVerify(StatusSuccess, string(output), nil)
@@ -1218,7 +1218,7 @@ func (t *Transaction) RegisterMultiSig(walletstr string, mswallet string) error 
 	sn := transaction.SmartContractTxnData{Name: MultiSigRegisterFuncName, InputArgs: msw}
 	snBytes, err := json.Marshal(sn)
 	if err != nil {
-		return common.WrapWithMessage(err, "execute multisig register failed due to invalid data.")
+		return common.WrapError(err, "execute multisig register failed due to invalid data.")
 	}
 	go func() {
 		t.txn.TransactionType = transaction.TxnTypeSmartContract
@@ -1263,7 +1263,7 @@ func (t *Transaction) RegisterVote(signerwalletstr string, msvstr string) error 
 	sn := transaction.SmartContractTxnData{Name: MultiSigVoteFuncName, InputArgs: msv}
 	snBytes, err := json.Marshal(sn)
 	if err != nil {
-		return common.WrapWithMessage(err, "execute multisig vote failed due to invalid data.")
+		return common.WrapError(err, "execute multisig vote failed due to invalid data.")
 	}
 	go func() {
 		t.txn.TransactionType = transaction.TxnTypeSmartContract

--- a/zcncore/transaction.go
+++ b/zcncore/transaction.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/0chain/gosdk/core/block"
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/encryption"
 	"github.com/0chain/gosdk/core/transaction"
 	"github.com/0chain/gosdk/core/util"
@@ -24,11 +25,11 @@ var (
 )
 
 var (
-	errNetwork          = common.NewError("network error. host not reachable")
-	errUserRejected     = common.NewError("rejected by user")
-	errAuthVerifyFailed = common.NewError("verfication failed for auth response")
-	errAuthTimeout      = common.NewError("auth timed out")
-	errAddSignature     = common.NewError("error adding signature")
+	errNetwork          = errors.NewError("network error. host not reachable")
+	errUserRejected     = errors.NewError("rejected by user")
+	errAuthVerifyFailed = errors.NewError("verfication failed for auth response")
+	errAuthTimeout      = errors.NewError("auth timed out")
+	errAddSignature     = errors.NewError("error adding signature")
 )
 
 // TransactionCallback needs to be implemented by the caller for transaction related APIs
@@ -162,7 +163,7 @@ func signWithWallet(hash string, wi interface{}) (string, error) {
 
 	if !ok {
 		fmt.Printf("Error in casting to wallet")
-		return "", common.NewError("error in casting to wallet")
+		return "", errors.NewError("error in casting to wallet")
 	}
 	sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
 	sigScheme.SetPrivateKey(w.Keys[0].PrivateKey)
@@ -259,7 +260,7 @@ func (t *Transaction) submitTxn() {
 	}
 	rate := consensus * 100 / float32(len(randomMiners))
 	if rate < consensusThresh {
-		t.completeTxn(StatusError, "", common.NewError(fmt.Sprintf("submit transaction failed. %s", tFailureRsp)))
+		t.completeTxn(StatusError, "", errors.NewError(fmt.Sprintf("submit transaction failed. %s", tFailureRsp)))
 		return
 	}
 	time.Sleep(3 * time.Second)
@@ -283,7 +284,7 @@ func NewTransaction(cb TransactionCallback, txnFee int64) (TransactionScheme, er
 	}
 	if _config.isSplitWallet {
 		if _config.authUrl == "" {
-			return nil, common.NewError("auth url not set")
+			return nil, errors.NewError("auth url not set")
 		}
 		Logger.Info("New transaction interface with auth")
 		return newTransactionWithAuth(cb, txnFee)
@@ -294,7 +295,7 @@ func NewTransaction(cb TransactionCallback, txnFee int64) (TransactionScheme, er
 
 func (t *Transaction) SetTransactionCallback(cb TransactionCallback) error {
 	if t.txnStatus != StatusUnknown {
-		return common.NewError("transaction already exists. cannot set transaction hash.")
+		return errors.NewError("transaction already exists. cannot set transaction hash.")
 	}
 	t.txnCb = cb
 	return nil
@@ -302,7 +303,7 @@ func (t *Transaction) SetTransactionCallback(cb TransactionCallback) error {
 
 func (t *Transaction) SetTransactionFee(txnFee int64) error {
 	if t.txnStatus != StatusUnknown {
-		return common.NewError("transaction already exists. cannot set transaction fee.")
+		return errors.NewError("transaction already exists. cannot set transaction fee.")
 	}
 	t.txn.TransactionFee = txnFee
 	return nil
@@ -346,7 +347,7 @@ func (t *Transaction) createSmartContractTxn(address, methodName string, input i
 	sn := transaction.SmartContractTxnData{Name: methodName, InputArgs: input}
 	snBytes, err := json.Marshal(sn)
 	if err != nil {
-		return common.WrapError(err, "create smart contract failed due to invalid data.")
+		return errors.WrapError(err, "create smart contract failed due to invalid data.")
 	}
 	t.txn.TransactionType = transaction.TxnTypeSmartContract
 	t.txn.ToClientID = address
@@ -397,7 +398,7 @@ func (t *Transaction) ExecuteSmartContract(address, methodName, jsoninput string
 
 func (t *Transaction) SetTransactionHash(hash string) error {
 	if t.txnStatus != StatusUnknown {
-		return common.NewError("transaction already exists. cannot set transaction hash.")
+		return errors.NewError("transaction already exists. cannot set transaction hash.")
 	}
 	t.txnHash = hash
 	return nil
@@ -461,20 +462,20 @@ func getBlockHeaderFromTransactionConfirmation(txnHash string, cfmBlock map[stri
 		var cfm confirmation
 		err := json.Unmarshal(cfmBytes, &cfm)
 		if err != nil {
-			return nil, common.WrapError(err, "txn confirmation parse error.")
+			return nil, errors.WrapError(err, "txn confirmation parse error.")
 		}
 		if cfm.Transaction == nil {
-			return nil, common.NewError(fmt.Sprintf("missing transaction %s in block confirmation", txnHash))
+			return nil, errors.NewError(fmt.Sprintf("missing transaction %s in block confirmation", txnHash))
 		}
 		if txnHash != cfm.Transaction.Hash {
-			return nil, common.NewError(fmt.Sprintf("invalid transaction hash. Expected: %s. Received: %s", txnHash, cfm.Transaction.Hash))
+			return nil, errors.NewError(fmt.Sprintf("invalid transaction hash. Expected: %s. Received: %s", txnHash, cfm.Transaction.Hash))
 		}
 		if !util.VerifyMerklePath(cfm.Transaction.Hash, cfm.MerkleTreePath, cfm.MerkleTreeRoot) {
-			return nil, common.NewError("txn merkle validation failed.")
+			return nil, errors.NewError("txn merkle validation failed.")
 		}
 		txnRcpt := transaction.NewTransactionReceipt(cfm.Transaction)
 		if !util.VerifyMerklePath(txnRcpt.GetHash(), cfm.ReceiptMerkleTreePath, cfm.ReceiptMerkleTreeRoot) {
-			return nil, common.NewError("txn receipt cmerkle validation failed.")
+			return nil, errors.NewError("txn receipt cmerkle validation failed.")
 		}
 		prevBlockHash := cfm.PreviousBlockHash
 		block.MinerId = cfm.MinerID
@@ -488,10 +489,10 @@ func getBlockHeaderFromTransactionConfirmation(txnHash string, cfmBlock map[stri
 		if isBlockExtends(prevBlockHash, block) {
 			return block, nil
 		} else {
-			return nil, common.NewError("block hash verification failed in confirmation")
+			return nil, errors.NewError("block hash verification failed in confirmation")
 		}
 	}
-	return nil, common.NewError("txn confirmation not found.")
+	return nil, errors.NewError("txn confirmation not found.")
 }
 
 func getTransactionConfirmation(numSharders int, txnHash string) (*blockHeader, map[string]json.RawMessage, *blockHeader, error) {
@@ -539,7 +540,7 @@ func getTransactionConfirmation(numSharders int, txnHash string) (*blockHeader, 
 		}
 	}
 	if maxConfirmation == 0 {
-		return nil, confirmation, &lfb, common.NewError("transaction not found")
+		return nil, confirmation, &lfb, errors.NewError("transaction not found")
 	}
 	return blockHdr, confirmation, &lfb, nil
 }
@@ -579,7 +580,7 @@ func GetLatestFinalized(ctx context.Context, numSharders int) (b *block.Header, 
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewError("block info not found")
+		return nil, errors.NewError("block info not found")
 	}
 
 	return
@@ -626,7 +627,7 @@ func GetLatestFinalizedMagicBlock(ctx context.Context, numSharders int) (m *bloc
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewError("magic block info not found")
+		return nil, errors.NewError("magic block info not found")
 	}
 
 	return
@@ -648,7 +649,7 @@ func GetChainStats(ctx context.Context) (b *block.ChainStats, err error) {
 	}
 
 	if rsp == nil {
-		return nil, common.NewError("http_request_failed", "Request failed with status not 200")
+		return nil, errors.NewError("http_request_failed", "Request failed with status not 200")
 	}
 
 	if err = json.Unmarshal([]byte(rsp.Body), &b); err != nil {
@@ -719,7 +720,7 @@ func GetBlockByRound(ctx context.Context, numSharders int, round int64) (b *bloc
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewError("round info not found")
+		return nil, errors.NewError("round info not found")
 	}
 
 	return
@@ -769,7 +770,7 @@ func GetMagicBlockByNumber(ctx context.Context, numSharders int, number int64) (
 	}
 
 	if maxConsensus == 0 {
-		return nil, common.NewError("magic block info not found")
+		return nil, errors.NewError("magic block info not found")
 	}
 
 	return
@@ -821,7 +822,7 @@ func getBlockInfoByRound(numSharders int, round int64, content string) (*blockHe
 		}
 	}
 	if maxConsensus == 0 {
-		return nil, common.NewError("round info not found.")
+		return nil, errors.NewError("round info not found.")
 	}
 	return &blkHdr, nil
 }
@@ -882,12 +883,12 @@ func (t *Transaction) isTransactionExpired(lfbCreationTime, currentTime int64) b
 }
 func (t *Transaction) Verify() error {
 	if t.txnHash == "" && t.txnStatus == StatusUnknown {
-		return common.NewError("invalid transaction. cannot be verified.")
+		return errors.NewError("invalid transaction. cannot be verified.")
 	}
 	if t.txnHash == "" && t.txnStatus == StatusSuccess {
 		h := t.GetTransactionHash()
 		if h == "" {
-			return common.NewError("invalid transaction. cannot be verified.")
+			return errors.NewError("invalid transaction. cannot be verified.")
 		}
 	}
 	// If transaction is verify only start from current time
@@ -907,14 +908,14 @@ func (t *Transaction) Verify() error {
 					confirmBlock, confirmation, lfb, err = getTransactionConfirmation(getMinShardersVerify(), t.txnHash)
 					if err != nil {
 						if t.isTransactionExpired(lfb.CreationDate, tn) {
-							t.completeVerify(StatusError, "", common.NewError(`{"error": "verify transaction failed"}`))
+							t.completeVerify(StatusError, "", errors.NewError(`{"error": "verify transaction failed"}`))
 							return
 						}
 						continue
 					}
 				} else {
 					if t.isTransactionExpired(lfb.CreationDate, tn) {
-						t.completeVerify(StatusError, "", common.NewError(`{"error": "verify transaction failed"}`))
+						t.completeVerify(StatusError, "", errors.NewError(`{"error": "verify transaction failed"}`))
 						return
 					}
 					continue
@@ -924,7 +925,7 @@ func (t *Transaction) Verify() error {
 			if valid {
 				output, err := json.Marshal(confirmation)
 				if err != nil {
-					t.completeVerify(StatusError, "", common.NewError(`{"error": "transaction confirmation json marshal error"`))
+					t.completeVerify(StatusError, "", errors.NewError(`{"error": "transaction confirmation json marshal error"`))
 					return
 				}
 				t.completeVerify(StatusSuccess, string(output), nil)
@@ -1218,7 +1219,7 @@ func (t *Transaction) RegisterMultiSig(walletstr string, mswallet string) error 
 	sn := transaction.SmartContractTxnData{Name: MultiSigRegisterFuncName, InputArgs: msw}
 	snBytes, err := json.Marshal(sn)
 	if err != nil {
-		return common.WrapError(err, "execute multisig register failed due to invalid data.")
+		return errors.WrapError(err, "execute multisig register failed due to invalid data.")
 	}
 	go func() {
 		t.txn.TransactionType = transaction.TxnTypeSmartContract
@@ -1263,7 +1264,7 @@ func (t *Transaction) RegisterVote(signerwalletstr string, msvstr string) error 
 	sn := transaction.SmartContractTxnData{Name: MultiSigVoteFuncName, InputArgs: msv}
 	snBytes, err := json.Marshal(sn)
 	if err != nil {
-		return common.WrapError(err, "execute multisig vote failed due to invalid data.")
+		return errors.WrapError(err, "execute multisig vote failed due to invalid data.")
 	}
 	go func() {
 		t.txn.TransactionType = transaction.TxnTypeSmartContract
@@ -1280,12 +1281,12 @@ func VerifyContentHash(metaTxnDataJSON string) (bool, error) {
 	var metaTxnData sdk.CommitMetaResponse
 	err := json.Unmarshal([]byte(metaTxnDataJSON), &metaTxnData)
 	if err != nil {
-		return false, common.NewError("metaTxnData_decode_error", "Unable to decode metaTxnData json")
+		return false, errors.NewError("metaTxnData_decode_error", "Unable to decode metaTxnData json")
 	}
 
 	t, err := transaction.VerifyTransaction(metaTxnData.TxnID, blockchain.GetSharders())
 	if err != nil {
-		return false, common.NewError("fetch_txm_details", "Unable to fetch txn details")
+		return false, errors.NewError("fetch_txm_details", "Unable to fetch txn details")
 	}
 
 	var metaOperation sdk.CommitMetaData

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -28,11 +28,11 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 	ta.t.txn.PublicKey = _config.wallet.Keys[0].PublicKey
 	err := ta.t.txn.ComputeHashAndSign(signFn)
 	if err != nil {
-		return nil, errors.WrapError(err, "signing error.")
+		return nil, errors.Wrap(err, "signing error.")
 	}
 	req, err := util.NewHTTPPostRequest(_config.authUrl+"/transaction", ta.t.txn)
 	if err != nil {
-		return nil, errors.WrapError(err, "new post request failed for auth")
+		return nil, errors.Wrap(err, "new post request failed for auth")
 	}
 	res, err := req.Post()
 	if err != nil {
@@ -42,12 +42,12 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 		if res.StatusCode == http.StatusUnauthorized {
 			return nil, errUserRejected
 		}
-		return nil, errors.NewError(strconv.Itoa(res.StatusCode), fmt.Sprintf("auth error: %v. %v", res.Status, res.Body))
+		return nil, errors.New(strconv.Itoa(res.StatusCode), fmt.Sprintf("auth error: %v. %v", res.Status, res.Body))
 	}
 	var txnResp transaction.Transaction
 	err = json.Unmarshal([]byte(res.Body), &txnResp)
 	if err != nil {
-		return nil, errors.WrapError(err, "invalid json on auth response.")
+		return nil, errors.Wrap(err, "invalid json on auth response.")
 	}
 	Logger.Debug(txnResp)
 	// Verify the signature on the result
@@ -93,7 +93,7 @@ func verifyFn(signature, msgHash, publicKey string) (bool, error) {
 	v.SetPublicKey(publicKey)
 	ok, err := v.Verify(signature, msgHash)
 	if err != nil || ok == false {
-		return false, errors.NewError(`{"error": "signature_mismatch"}`)
+		return false, errors.New(`{"error": "signature_mismatch"}`)
 	}
 	return true, nil
 }
@@ -353,7 +353,7 @@ func (ta *TransactionWithAuth) UnlockTokens(poolID string) error {
 
 //RegisterMultiSig register a multisig wallet with the SC.
 func (ta *TransactionWithAuth) RegisterMultiSig(walletstr string, mswallet string) error {
-	return errors.NewError("not implemented")
+	return errors.New("not implemented")
 }
 
 //

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
+	"github.com/0chain/gosdk/core/common"
 	"github.com/0chain/gosdk/core/transaction"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/core/zcncrypto"
@@ -26,11 +28,11 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 	ta.t.txn.PublicKey = _config.wallet.Keys[0].PublicKey
 	err := ta.t.txn.ComputeHashAndSign(signFn)
 	if err != nil {
-		return nil, fmt.Errorf("signing error. %v", err.Error())
+		return nil, common.WrapWithMessage(err, "signing error.")
 	}
 	req, err := util.NewHTTPPostRequest(_config.authUrl+"/transaction", ta.t.txn)
 	if err != nil {
-		return nil, fmt.Errorf("new post request failed for auth %v", err.Error())
+		return nil, common.WrapWithMessage(err, "new post request failed for auth")
 	}
 	res, err := req.Post()
 	if err != nil {
@@ -40,12 +42,12 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 		if res.StatusCode == http.StatusUnauthorized {
 			return nil, errUserRejected
 		}
-		return nil, fmt.Errorf("auth error: %v. %v", res.Status, res.Body)
+		return nil, common.NewError(strconv.Itoa(res.StatusCode), fmt.Sprintf("auth error: %v. %v", res.Status, res.Body))
 	}
 	var txnResp transaction.Transaction
 	err = json.Unmarshal([]byte(res.Body), &txnResp)
 	if err != nil {
-		return nil, fmt.Errorf("invalid json on auth response. %v", err)
+		return nil, common.WrapWithMessage(err, "invalid json on auth response.")
 	}
 	Logger.Debug(txnResp)
 	// Verify the signature on the result
@@ -91,7 +93,7 @@ func verifyFn(signature, msgHash, publicKey string) (bool, error) {
 	v.SetPublicKey(publicKey)
 	ok, err := v.Verify(signature, msgHash)
 	if err != nil || ok == false {
-		return false, fmt.Errorf(`{"error": "signature_mismatch"}`)
+		return false, common.NewErrorMessage(`{"error": "signature_mismatch"}`)
 	}
 	return true, nil
 }
@@ -351,7 +353,7 @@ func (ta *TransactionWithAuth) UnlockTokens(poolID string) error {
 
 //RegisterMultiSig register a multisig wallet with the SC.
 func (ta *TransactionWithAuth) RegisterMultiSig(walletstr string, mswallet string) error {
-	return fmt.Errorf("not implemented")
+	return common.NewErrorMessage("not implemented")
 }
 
 //

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -28,11 +28,11 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 	ta.t.txn.PublicKey = _config.wallet.Keys[0].PublicKey
 	err := ta.t.txn.ComputeHashAndSign(signFn)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "signing error.")
+		return nil, common.WrapError(err, "signing error.")
 	}
 	req, err := util.NewHTTPPostRequest(_config.authUrl+"/transaction", ta.t.txn)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "new post request failed for auth")
+		return nil, common.WrapError(err, "new post request failed for auth")
 	}
 	res, err := req.Post()
 	if err != nil {
@@ -47,7 +47,7 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 	var txnResp transaction.Transaction
 	err = json.Unmarshal([]byte(res.Body), &txnResp)
 	if err != nil {
-		return nil, common.WrapWithMessage(err, "invalid json on auth response.")
+		return nil, common.WrapError(err, "invalid json on auth response.")
 	}
 	Logger.Debug(txnResp)
 	// Verify the signature on the result
@@ -93,7 +93,7 @@ func verifyFn(signature, msgHash, publicKey string) (bool, error) {
 	v.SetPublicKey(publicKey)
 	ok, err := v.Verify(signature, msgHash)
 	if err != nil || ok == false {
-		return false, common.NewErrorMessage(`{"error": "signature_mismatch"}`)
+		return false, common.NewError(`{"error": "signature_mismatch"}`)
 	}
 	return true, nil
 }
@@ -353,7 +353,7 @@ func (ta *TransactionWithAuth) UnlockTokens(poolID string) error {
 
 //RegisterMultiSig register a multisig wallet with the SC.
 func (ta *TransactionWithAuth) RegisterMultiSig(walletstr string, mswallet string) error {
-	return common.NewErrorMessage("not implemented")
+	return common.NewError("not implemented")
 }
 
 //

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/transaction"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/core/zcncrypto"
@@ -28,11 +28,11 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 	ta.t.txn.PublicKey = _config.wallet.Keys[0].PublicKey
 	err := ta.t.txn.ComputeHashAndSign(signFn)
 	if err != nil {
-		return nil, common.WrapError(err, "signing error.")
+		return nil, errors.WrapError(err, "signing error.")
 	}
 	req, err := util.NewHTTPPostRequest(_config.authUrl+"/transaction", ta.t.txn)
 	if err != nil {
-		return nil, common.WrapError(err, "new post request failed for auth")
+		return nil, errors.WrapError(err, "new post request failed for auth")
 	}
 	res, err := req.Post()
 	if err != nil {
@@ -42,12 +42,12 @@ func (ta *TransactionWithAuth) getAuthorize() (*transaction.Transaction, error) 
 		if res.StatusCode == http.StatusUnauthorized {
 			return nil, errUserRejected
 		}
-		return nil, common.NewError(strconv.Itoa(res.StatusCode), fmt.Sprintf("auth error: %v. %v", res.Status, res.Body))
+		return nil, errors.NewError(strconv.Itoa(res.StatusCode), fmt.Sprintf("auth error: %v. %v", res.Status, res.Body))
 	}
 	var txnResp transaction.Transaction
 	err = json.Unmarshal([]byte(res.Body), &txnResp)
 	if err != nil {
-		return nil, common.WrapError(err, "invalid json on auth response.")
+		return nil, errors.WrapError(err, "invalid json on auth response.")
 	}
 	Logger.Debug(txnResp)
 	// Verify the signature on the result
@@ -93,7 +93,7 @@ func verifyFn(signature, msgHash, publicKey string) (bool, error) {
 	v.SetPublicKey(publicKey)
 	ok, err := v.Verify(signature, msgHash)
 	if err != nil || ok == false {
-		return false, common.NewError(`{"error": "signature_mismatch"}`)
+		return false, errors.NewError(`{"error": "signature_mismatch"}`)
 	}
 	return true, nil
 }
@@ -353,7 +353,7 @@ func (ta *TransactionWithAuth) UnlockTokens(poolID string) error {
 
 //RegisterMultiSig register a multisig wallet with the SC.
 func (ta *TransactionWithAuth) RegisterMultiSig(walletstr string, mswallet string) error {
-	return common.NewError("not implemented")
+	return errors.NewError("not implemented")
 }
 
 //

--- a/zcncore/wallet.go
+++ b/zcncore/wallet.go
@@ -199,14 +199,14 @@ func init() {
 }
 func checkSdkInit() error {
 	if !_config.isConfigured || len(_config.chain.Miners) < 1 || len(_config.chain.Sharders) < 1 {
-		return errors.NewError("SDK not initialized")
+		return errors.New("SDK not initialized")
 	}
 	return nil
 }
 func checkWalletConfig() error {
 	if !_config.isValidWallet || _config.wallet.ClientID == "" {
 		Logger.Error("wallet info not found. returning error.")
-		return errors.NewError("wallet info not found. set wallet info")
+		return errors.New("wallet info not found. set wallet info")
 	}
 	return nil
 }
@@ -293,7 +293,7 @@ func Init(c string) error {
 	if err == nil {
 		// Check signature scheme is supported
 		if _config.chain.SignatureScheme != "ed25519" && _config.chain.SignatureScheme != "bls0chain" {
-			return errors.NewError("invalid/unsupported signature scheme")
+			return errors.New("invalid/unsupported signature scheme")
 		}
 
 		err := UpdateNetworkDetails()
@@ -341,7 +341,7 @@ func WithConfirmationChainLength(m int) func(c *ChainConfig) error {
 // InitZCNSDK initializes the SDK with miner, sharder and signature scheme provided.
 func InitZCNSDK(blockWorker string, signscheme string, configs ...func(*ChainConfig) error) error {
 	if signscheme != "ed25519" && signscheme != "bls0chain" {
-		return errors.NewError("invalid/unsupported signature scheme")
+		return errors.New("invalid/unsupported signature scheme")
 	}
 	_config.chain.BlockWorker = blockWorker
 	_config.chain.SignatureScheme = signscheme
@@ -356,7 +356,7 @@ func InitZCNSDK(blockWorker string, signscheme string, configs ...func(*ChainCon
 	for _, conf := range configs {
 		err := conf(&_config.chain)
 		if err != nil {
-			return errors.WrapError(err, "invalid/unsupported options.")
+			return errors.Wrap(err, "invalid/unsupported options.")
 		}
 	}
 	assertConfig()
@@ -387,7 +387,7 @@ func GetNetworkJSON() string {
 // It also registers the wallet again to block chain.
 func CreateWallet(statusCb WalletCallback) error {
 	if len(_config.chain.Miners) < 1 || len(_config.chain.Sharders) < 1 {
-		return errors.NewError("SDK not initialized")
+		return errors.New("SDK not initialized")
 	}
 	go func() {
 		sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
@@ -409,7 +409,7 @@ func CreateWallet(statusCb WalletCallback) error {
 // It also registers the wallet again to block chain.
 func RecoverWallet(mnemonic string, statusCb WalletCallback) error {
 	if zcncrypto.IsMnemonicValid(mnemonic) != true {
-		return errors.NewError("Invalid mnemonic")
+		return errors.New("Invalid mnemonic")
 	}
 	go func() {
 		sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
@@ -430,20 +430,20 @@ func RecoverWallet(mnemonic string, statusCb WalletCallback) error {
 // Split keys from the primary master key
 func SplitKeys(privateKey string, numSplits int) (string, error) {
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", errors.NewError("signature key doesn't support split key")
+		return "", errors.New("signature key doesn't support split key")
 	}
 	sigScheme := zcncrypto.NewBLS0ChainScheme()
 	err := sigScheme.SetPrivateKey(privateKey)
 	if err != nil {
-		return "", errors.WrapError(err, "set private key failed")
+		return "", errors.Wrap(err, "set private key failed")
 	}
 	w, err := sigScheme.SplitKeys(numSplits)
 	if err != nil {
-		return "", errors.WrapError(err, "split key failed.")
+		return "", errors.Wrap(err, "split key failed.")
 	}
 	wStr, err := w.Marshal()
 	if err != nil {
-		return "", errors.WrapError(err, "wallet encoding failed.")
+		return "", errors.Wrap(err, "wallet encoding failed.")
 	}
 	return wStr, nil
 }
@@ -488,11 +488,11 @@ func RegisterToMiners(wallet *zcncrypto.Wallet, statusCb WalletCallback) error {
 	}
 	rate := consensus * 100 / float32(len(_config.chain.Miners))
 	if rate < consensusThresh {
-		return errors.NewError(fmt.Sprintf("Register consensus not met. Consensus: %f, Expected: %f", rate, consensusThresh))
+		return errors.New(fmt.Sprintf("Register consensus not met. Consensus: %f, Expected: %f", rate, consensusThresh))
 	}
 	w, err := wallet.Marshal()
 	if err != nil {
-		return errors.WrapError(err, "wallet encoding failed")
+		return errors.Wrap(err, "wallet encoding failed")
 	}
 	statusCb.OnWalletCreateComplete(StatusSuccess, w, "")
 	return nil
@@ -550,10 +550,10 @@ func SetWalletInfo(w string, splitKeyWallet bool) error {
 // SetAuthUrl will be called by app to set zauth URL to SDK.
 func SetAuthUrl(url string) error {
 	if !_config.isSplitWallet {
-		return errors.NewError("wallet type is not split key")
+		return errors.New("wallet type is not split key")
 	}
 	if url == "" {
-		return errors.NewError("invalid auth url")
+		return errors.New("invalid auth url")
 	}
 	_config.authUrl = strings.TrimRight(url, "/")
 	return nil
@@ -640,7 +640,7 @@ func getBalanceFromSharders(clientID string) (int64, string, error) {
 	}
 	rate := consensus * 100 / float32(len(_config.chain.Sharders))
 	if rate < consensusThresh {
-		return 0, winError, errors.NewError("get balance failed. consensus not reached")
+		return 0, winError, errors.New("get balance failed. consensus not reached")
 	}
 	return winBalance, winInfo, nil
 }
@@ -694,7 +694,7 @@ func getTokenUSDRate() (float64, error) {
 
 	if res.StatusCode != http.StatusOK {
 		Logger.Error("Response status not OK. ", res.StatusCode)
-		return 0, errors.NewError("invalid_res_status_code", "Response status code is not OK")
+		return 0, errors.New("invalid_res_status_code", "Response status code is not OK")
 	}
 
 	err = json.Unmarshal([]byte(res.Body), &CoinGeckoResponse)

--- a/zcncore/wallet.go
+++ b/zcncore/wallet.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/0chain/gosdk/core/common"
+	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/core/logger"
 	"github.com/0chain/gosdk/core/util"
 	"github.com/0chain/gosdk/core/version"
@@ -198,14 +199,14 @@ func init() {
 }
 func checkSdkInit() error {
 	if !_config.isConfigured || len(_config.chain.Miners) < 1 || len(_config.chain.Sharders) < 1 {
-		return common.NewError("SDK not initialized")
+		return errors.NewError("SDK not initialized")
 	}
 	return nil
 }
 func checkWalletConfig() error {
 	if !_config.isValidWallet || _config.wallet.ClientID == "" {
 		Logger.Error("wallet info not found. returning error.")
-		return common.NewError("wallet info not found. set wallet info")
+		return errors.NewError("wallet info not found. set wallet info")
 	}
 	return nil
 }
@@ -292,7 +293,7 @@ func Init(c string) error {
 	if err == nil {
 		// Check signature scheme is supported
 		if _config.chain.SignatureScheme != "ed25519" && _config.chain.SignatureScheme != "bls0chain" {
-			return common.NewError("invalid/unsupported signature scheme")
+			return errors.NewError("invalid/unsupported signature scheme")
 		}
 
 		err := UpdateNetworkDetails()
@@ -340,7 +341,7 @@ func WithConfirmationChainLength(m int) func(c *ChainConfig) error {
 // InitZCNSDK initializes the SDK with miner, sharder and signature scheme provided.
 func InitZCNSDK(blockWorker string, signscheme string, configs ...func(*ChainConfig) error) error {
 	if signscheme != "ed25519" && signscheme != "bls0chain" {
-		return common.NewError("invalid/unsupported signature scheme")
+		return errors.NewError("invalid/unsupported signature scheme")
 	}
 	_config.chain.BlockWorker = blockWorker
 	_config.chain.SignatureScheme = signscheme
@@ -355,7 +356,7 @@ func InitZCNSDK(blockWorker string, signscheme string, configs ...func(*ChainCon
 	for _, conf := range configs {
 		err := conf(&_config.chain)
 		if err != nil {
-			return common.WrapError(err, "invalid/unsupported options.")
+			return errors.WrapError(err, "invalid/unsupported options.")
 		}
 	}
 	assertConfig()
@@ -386,7 +387,7 @@ func GetNetworkJSON() string {
 // It also registers the wallet again to block chain.
 func CreateWallet(statusCb WalletCallback) error {
 	if len(_config.chain.Miners) < 1 || len(_config.chain.Sharders) < 1 {
-		return common.NewError("SDK not initialized")
+		return errors.NewError("SDK not initialized")
 	}
 	go func() {
 		sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
@@ -408,7 +409,7 @@ func CreateWallet(statusCb WalletCallback) error {
 // It also registers the wallet again to block chain.
 func RecoverWallet(mnemonic string, statusCb WalletCallback) error {
 	if zcncrypto.IsMnemonicValid(mnemonic) != true {
-		return common.NewError("Invalid mnemonic")
+		return errors.NewError("Invalid mnemonic")
 	}
 	go func() {
 		sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
@@ -429,20 +430,20 @@ func RecoverWallet(mnemonic string, statusCb WalletCallback) error {
 // Split keys from the primary master key
 func SplitKeys(privateKey string, numSplits int) (string, error) {
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", common.NewError("signature key doesn't support split key")
+		return "", errors.NewError("signature key doesn't support split key")
 	}
 	sigScheme := zcncrypto.NewBLS0ChainScheme()
 	err := sigScheme.SetPrivateKey(privateKey)
 	if err != nil {
-		return "", common.WrapError(err, "set private key failed")
+		return "", errors.WrapError(err, "set private key failed")
 	}
 	w, err := sigScheme.SplitKeys(numSplits)
 	if err != nil {
-		return "", common.WrapError(err, "split key failed.")
+		return "", errors.WrapError(err, "split key failed.")
 	}
 	wStr, err := w.Marshal()
 	if err != nil {
-		return "", common.WrapError(err, "wallet encoding failed.")
+		return "", errors.WrapError(err, "wallet encoding failed.")
 	}
 	return wStr, nil
 }
@@ -487,11 +488,11 @@ func RegisterToMiners(wallet *zcncrypto.Wallet, statusCb WalletCallback) error {
 	}
 	rate := consensus * 100 / float32(len(_config.chain.Miners))
 	if rate < consensusThresh {
-		return common.NewError(fmt.Sprintf("Register consensus not met. Consensus: %f, Expected: %f", rate, consensusThresh))
+		return errors.NewError(fmt.Sprintf("Register consensus not met. Consensus: %f, Expected: %f", rate, consensusThresh))
 	}
 	w, err := wallet.Marshal()
 	if err != nil {
-		return common.WrapError(err, "wallet encoding failed")
+		return errors.WrapError(err, "wallet encoding failed")
 	}
 	statusCb.OnWalletCreateComplete(StatusSuccess, w, "")
 	return nil
@@ -549,10 +550,10 @@ func SetWalletInfo(w string, splitKeyWallet bool) error {
 // SetAuthUrl will be called by app to set zauth URL to SDK.
 func SetAuthUrl(url string) error {
 	if !_config.isSplitWallet {
-		return common.NewError("wallet type is not split key")
+		return errors.NewError("wallet type is not split key")
 	}
 	if url == "" {
-		return common.NewError("invalid auth url")
+		return errors.NewError("invalid auth url")
 	}
 	_config.authUrl = strings.TrimRight(url, "/")
 	return nil
@@ -639,7 +640,7 @@ func getBalanceFromSharders(clientID string) (int64, string, error) {
 	}
 	rate := consensus * 100 / float32(len(_config.chain.Sharders))
 	if rate < consensusThresh {
-		return 0, winError, common.NewError("get balance failed. consensus not reached")
+		return 0, winError, errors.NewError("get balance failed. consensus not reached")
 	}
 	return winBalance, winInfo, nil
 }
@@ -693,7 +694,7 @@ func getTokenUSDRate() (float64, error) {
 
 	if res.StatusCode != http.StatusOK {
 		Logger.Error("Response status not OK. ", res.StatusCode)
-		return 0, common.NewError("invalid_res_status_code", "Response status code is not OK")
+		return 0, errors.NewError("invalid_res_status_code", "Response status code is not OK")
 	}
 
 	err = json.Unmarshal([]byte(res.Body), &CoinGeckoResponse)

--- a/zcncore/wallet.go
+++ b/zcncore/wallet.go
@@ -198,14 +198,14 @@ func init() {
 }
 func checkSdkInit() error {
 	if !_config.isConfigured || len(_config.chain.Miners) < 1 || len(_config.chain.Sharders) < 1 {
-		return fmt.Errorf("SDK not initialized")
+		return common.NewErrorMessage("SDK not initialized")
 	}
 	return nil
 }
 func checkWalletConfig() error {
 	if !_config.isValidWallet || _config.wallet.ClientID == "" {
 		Logger.Error("wallet info not found. returning error.")
-		return fmt.Errorf("wallet info not found. set wallet info")
+		return common.NewErrorMessage("wallet info not found. set wallet info")
 	}
 	return nil
 }
@@ -292,7 +292,7 @@ func Init(c string) error {
 	if err == nil {
 		// Check signature scheme is supported
 		if _config.chain.SignatureScheme != "ed25519" && _config.chain.SignatureScheme != "bls0chain" {
-			return fmt.Errorf("invalid/unsupported signature scheme")
+			return common.NewErrorMessage("invalid/unsupported signature scheme")
 		}
 
 		err := UpdateNetworkDetails()
@@ -340,7 +340,7 @@ func WithConfirmationChainLength(m int) func(c *ChainConfig) error {
 // InitZCNSDK initializes the SDK with miner, sharder and signature scheme provided.
 func InitZCNSDK(blockWorker string, signscheme string, configs ...func(*ChainConfig) error) error {
 	if signscheme != "ed25519" && signscheme != "bls0chain" {
-		return fmt.Errorf("invalid/unsupported signature scheme")
+		return common.NewErrorMessage("invalid/unsupported signature scheme")
 	}
 	_config.chain.BlockWorker = blockWorker
 	_config.chain.SignatureScheme = signscheme
@@ -355,7 +355,7 @@ func InitZCNSDK(blockWorker string, signscheme string, configs ...func(*ChainCon
 	for _, conf := range configs {
 		err := conf(&_config.chain)
 		if err != nil {
-			return fmt.Errorf("invalid/unsupported options. %s", err)
+			return common.WrapWithMessage(err, "invalid/unsupported options.")
 		}
 	}
 	assertConfig()
@@ -386,7 +386,7 @@ func GetNetworkJSON() string {
 // It also registers the wallet again to block chain.
 func CreateWallet(statusCb WalletCallback) error {
 	if len(_config.chain.Miners) < 1 || len(_config.chain.Sharders) < 1 {
-		return fmt.Errorf("SDK not initialized")
+		return common.NewErrorMessage("SDK not initialized")
 	}
 	go func() {
 		sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
@@ -408,7 +408,7 @@ func CreateWallet(statusCb WalletCallback) error {
 // It also registers the wallet again to block chain.
 func RecoverWallet(mnemonic string, statusCb WalletCallback) error {
 	if zcncrypto.IsMnemonicValid(mnemonic) != true {
-		return fmt.Errorf("Invalid mnemonic")
+		return common.NewErrorMessage("Invalid mnemonic")
 	}
 	go func() {
 		sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
@@ -429,20 +429,20 @@ func RecoverWallet(mnemonic string, statusCb WalletCallback) error {
 // Split keys from the primary master key
 func SplitKeys(privateKey string, numSplits int) (string, error) {
 	if _config.chain.SignatureScheme != "bls0chain" {
-		return "", fmt.Errorf("signature key doesn't support split key")
+		return "", common.NewErrorMessage("signature key doesn't support split key")
 	}
 	sigScheme := zcncrypto.NewBLS0ChainScheme()
 	err := sigScheme.SetPrivateKey(privateKey)
 	if err != nil {
-		return "", fmt.Errorf("set private key failed - %s", err.Error())
+		return "", common.WrapWithMessage(err, "set private key failed")
 	}
 	w, err := sigScheme.SplitKeys(numSplits)
 	if err != nil {
-		return "", fmt.Errorf("split key failed. %s", err.Error())
+		return "", common.WrapWithMessage(err, "split key failed.")
 	}
 	wStr, err := w.Marshal()
 	if err != nil {
-		return "", fmt.Errorf("wallet encoding failed. %s", err.Error())
+		return "", common.WrapWithMessage(err, "wallet encoding failed.")
 	}
 	return wStr, nil
 }
@@ -487,11 +487,11 @@ func RegisterToMiners(wallet *zcncrypto.Wallet, statusCb WalletCallback) error {
 	}
 	rate := consensus * 100 / float32(len(_config.chain.Miners))
 	if rate < consensusThresh {
-		return fmt.Errorf("Register consensus not met. Consensus: %f, Expected: %f", rate, consensusThresh)
+		return common.NewErrorMessage(fmt.Sprintf("Register consensus not met. Consensus: %f, Expected: %f", rate, consensusThresh))
 	}
 	w, err := wallet.Marshal()
 	if err != nil {
-		return fmt.Errorf("wallet encoding failed - %s", err.Error())
+		return common.WrapWithMessage(err, "wallet encoding failed")
 	}
 	statusCb.OnWalletCreateComplete(StatusSuccess, w, "")
 	return nil
@@ -549,10 +549,10 @@ func SetWalletInfo(w string, splitKeyWallet bool) error {
 // SetAuthUrl will be called by app to set zauth URL to SDK.
 func SetAuthUrl(url string) error {
 	if !_config.isSplitWallet {
-		return fmt.Errorf("wallet type is not split key")
+		return common.NewErrorMessage("wallet type is not split key")
 	}
 	if url == "" {
-		return fmt.Errorf("invalid auth url")
+		return common.NewErrorMessage("invalid auth url")
 	}
 	_config.authUrl = strings.TrimRight(url, "/")
 	return nil
@@ -639,7 +639,7 @@ func getBalanceFromSharders(clientID string) (int64, string, error) {
 	}
 	rate := consensus * 100 / float32(len(_config.chain.Sharders))
 	if rate < consensusThresh {
-		return 0, winError, fmt.Errorf("get balance failed. consensus not reached")
+		return 0, winError, common.NewErrorMessage("get balance failed. consensus not reached")
 	}
 	return winBalance, winInfo, nil
 }


### PR DESCRIPTION
### Problem:
https://github.com/0chain/zboxcli/issues/53

Two Issues in general: 
1. Generic error message is shown to the user and the original error message context is lost 
2. We lost all the way error is passed through the stack. Having a stack is helpful for developers to quickly identify and resolve the issue. 

### Solution
Implemented a couple of functions `WrapWithError` and `WrapWithMessage`. These should be used from now to wrap any error that is being returned. 

### Sample Usage
```
package main

import (
	"fmt"
	"github.com/0chain/gosdk/core/common"
)

func main()  {
	username := "mysql"
	password := "password"
	err := registerUser(username, password)
	fmt.Println(err.Error())
}


func registerUser(username string, password string) error{
	err := validateCredentials(username, password)
	if err != nil {
		return common.WrapWithError(err, common.NewError("401", "unauthorized!"))
	}
	// registration logic
	return nil
}

func validateCredentials(username string, password string) error{
	err := validatePassword(password)
	if err != nil {
		return common.WrapWithMessage(err, "validation_error" )
	}
	return nil
}


func validatePassword(password string) error {
	//some password validation logic
	err := common.NewError("password", "must contain 2 special characters!")
	if err != nil {
		return err
	}
	return nil
}

```

### Sample Output
```
❯ go run main.go                                                                                                                                                                                                                                                                                                   
/Users/personal/workspace/0chain/better_errors/main.go:19 401: unauthorized!
/Users/personal/workspace/0chain/better_errors/main.go:28 validation_error
/Users/personal/workspace/0chain/better_errors/main.go:36 password: must contain 2 special characters!
```