### PR TITLE
[BUG] Resolving bug with shared files

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,8 @@ github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM52
 github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.2/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
+github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6/go.mod h1:+ZoRqAPRLkC4NPOvfYeR5KNOrY6TD+/sAC3HXPZgDYg=
 github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/reedsolomon v1.9.11 h1:n2kipJFo+CPqg7fH988XJXjqEyj14RJ8BYj7UayxPNg=

--- a/zboxcore/marker/authticket.go
+++ b/zboxcore/marker/authticket.go
@@ -12,7 +12,7 @@ type AuthTicket struct {
 	OwnerID         string `json:"owner_id"`
 	AllocationID    string `json:"allocation_id"`
 	FilePathHash    string `json:"file_path_hash"`
-	ContentHash     string `json:"content_hash"`
+	ActualFileHash  string `json:"actual_file_hash"`
 	FileName        string `json:"file_name"`
 	RefType         string `json:"reference_type"`
 	Expiration      int64  `json:"expiration"`
@@ -23,7 +23,7 @@ type AuthTicket struct {
 }
 
 func (rm *AuthTicket) GetHashData() string {
-	hashData := fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v", rm.AllocationID, rm.ClientID, rm.OwnerID, rm.FilePathHash, rm.FileName, rm.RefType, rm.ReEncryptionKey, rm.Expiration, rm.Timestamp, rm.ContentHash, rm.Encrypted)
+	hashData := fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v:%v:%v:%v", rm.AllocationID, rm.ClientID, rm.OwnerID, rm.FilePathHash, rm.FileName, rm.RefType, rm.ReEncryptionKey, rm.Expiration, rm.Timestamp, rm.ActualFileHash, rm.Encrypted)
 	return hashData
 }
 

--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -5,11 +5,12 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"go.dedis.ch/kyber/v3/group/edwards25519"
 	"io"
 	"math"
 	"os"
 	"sync"
+
+	"go.dedis.ch/kyber/v3/group/edwards25519"
 
 	"github.com/0chain/gosdk/core/common/errors"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
@@ -113,7 +114,7 @@ func (req *DownloadRequest) downloadBlock(blockNum int64, blockChunksMax int) ([
 			if blockChunksMax < len(result.BlockChunks) {
 				downloadChunks = blockChunksMax
 			}
-			//for blockNum := 0; blockNum < len(result.BlockChunks); blockNum++ {
+
 			for blockNum := 0; blockNum < downloadChunks; blockNum++ {
 				if len(req.encryptedKey) > 0 {
 					suite := edwards25519.NewBlakeSHA256Ed25519()
@@ -242,11 +243,8 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 	startBlock := req.startBlock
 	endBlock := req.endBlock
 	numBlocks := req.numBlocks
-	//batchCount := (chunksPerShard + req.numBlocks - 1) / req.numBlocks
-	//for cnt := req.startBlock; cnt < req.endBlock; cnt += req.numBlocks {
-	for startBlock < endBlock {
-		//blockSize := int64(math.Min(float64(perShard-(cnt*fileref.CHUNK_SIZE)), fileref.CHUNK_SIZE))
 
+	for startBlock < endBlock {
 		cnt := startBlock
 		Logger.Info("Downloading block ", cnt+1)
 		if (startBlock + numBlocks) > endBlock {
@@ -269,7 +267,7 @@ func (req *DownloadRequest) processDownload(ctx context.Context) {
 			}
 			return
 		}
-		//fmt.Println("Length of decoded data:", len(data))
+
 		n := int64(math.Min(float64(size), float64(len(data))))
 		_, err = mW.Write(data[:n])
 		if err != nil {

--- a/zboxcore/sdk/sharerequest.go
+++ b/zboxcore/sdk/sharerequest.go
@@ -41,7 +41,7 @@ func (req *ShareRequest) GetAuthTicketForEncryptedFile(clientID string, encPubli
 	if err != nil {
 		return "", err
 	}
-	at.ContentHash = fileRef.ContentHash
+	at.ActualFileHash = fileRef.ActualFileHash
 
 	if req.expirationSeconds == 0 {
 		// default expiration after 90 days
@@ -107,7 +107,8 @@ func (req *ShareRequest) GetAuthTicket(clientID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	at.ContentHash = fileRef.ContentHash
+
+	at.ActualFileHash = fileRef.ActualFileHash
 
 	timestamp := int64(common.Now())
 	if req.expirationSeconds == 0 {


### PR DESCRIPTION
Resolving bug with sharing files. When we trying to download shared files we sending AuthTicket - it contains field 'ContentHash', this 'ContentHash' picked up from `--share` function only from single blobber. 

Meantime blobber has check if 'ContentHash' != ref.ContentHash then it will reject request, that seems strange as ContentHash are not unique per blobbers and generated randomly (each blobber has it's own ContentHash for same file), altrought on blobber side this field seems useless for me.

Changed to ActualFileHash from both sides (gosdk and blobber repo) - this check happens only for Files, so it will not affect folder sharing

blobber PR: https://github.com/0chain/blobber/pull/278 