### PR TITLE
chore: remove redundant build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -1,5 +1,0 @@
-package gosdk
-
-func init() {
-
-}


### PR DESCRIPTION
This file is left unchanged for past two years, still wasn't cleaned up