### PR TITLE
Split update_settings into update_miner_settings and update_sharder_settings

### DIFF
--- a/core/transaction/entity.go
+++ b/core/transaction/entity.go
@@ -108,9 +108,10 @@ const (
 	STORAGESC_CURATOR_TRANSFER         = "curator_transfer_allocation"
 
 	// Miner SC
-	MINERSC_LOCK     = "addToDelegatePool"
-	MINERSC_UNLOCK   = "deleteFromDelegatePool"
-	MINERSC_SETTINGS = "update_settings"
+	MINERSC_LOCK             = "addToDelegatePool"
+	MINERSC_UNLOCK           = "deleteFromDelegatePool"
+	MINERSC_MINER_SETTINGS   = "update_miner_settings"
+	MINERSC_SHARDER_SETTINGS = "update_sharder_settings"
 )
 
 type SignFunc = func(msg string) (string, error)

--- a/zcncore/transaction.go
+++ b/zcncore/transaction.go
@@ -131,7 +131,8 @@ type TransactionScheme interface {
 
 	// Miner SC
 
-	MinerSCSettings(*MinerSCMinerInfo) error
+	MinerSCMinerSettings(*MinerSCMinerInfo) error
+	MinerSCSharderSettings(*MinerSCMinerInfo) error
 	MinerSCLock(minerID string, lock int64) error
 	MienrSCUnlock(minerID, poolID string) error
 
@@ -1093,13 +1094,13 @@ type MinerSCMinerStat struct {
 }
 
 type MinerSCMinerInfo struct {
-	*SimpleMienrSCMinerInfo `json:"simple_miner"`
+	*SimpleMinerSCMinerInfo `json:"simple_miner"`
 	Pending                 map[string]MinerSCDelegatePool `json:"pending"`
 	Active                  map[string]MinerSCDelegatePool `json:"active"`
 	Deleting                map[string]MinerSCDelegatePool `json:"deleting"`
 }
 
-type SimpleMienrSCMinerInfo struct {
+type SimpleMinerSCMinerInfo struct {
 	ID      string `json:"id"`
 	BaseURL string `json:"url"`
 
@@ -1112,9 +1113,20 @@ type SimpleMienrSCMinerInfo struct {
 	Stat MinerSCMinerStat `json:"stat"`
 }
 
-func (t *Transaction) MinerSCSettings(info *MinerSCMinerInfo) (err error) {
+func (t *Transaction) MinerSCMinerSettings(info *MinerSCMinerInfo) (err error) {
 	err = t.createSmartContractTxn(MinerSmartContractAddress,
-		transaction.MINERSC_SETTINGS, info, 0)
+		transaction.MINERSC_MINER_SETTINGS, info, 0)
+	if err != nil {
+		Logger.Error(err)
+		return
+	}
+	go func() { t.submitTxn() }()
+	return
+}
+
+func (t *Transaction) MinerSCSharderSettings(info *MinerSCMinerInfo) (err error) {
+	err = t.createSmartContractTxn(MinerSmartContractAddress,
+		transaction.MINERSC_SHARDER_SETTINGS, info, 0)
 	if err != nil {
 		Logger.Error(err)
 		return

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -277,11 +277,24 @@ func (ta *TransactionWithAuth) VestingUpdateConfig(
 // miner sc
 //
 
-func (ta *TransactionWithAuth) MinerSCSettings(info *MinerSCMinerInfo) (
+func (ta *TransactionWithAuth) MinerSCMinerSettings(info *MinerSCMinerInfo) (
 	err error) {
 
 	err = ta.t.createSmartContractTxn(MinerSmartContractAddress,
-		transaction.MINERSC_SETTINGS, info, 0)
+		transaction.MINERSC_MINER_SETTINGS, info, 0)
+	if err != nil {
+		Logger.Error(err)
+		return
+	}
+	go func() { ta.submitTxn() }()
+	return
+}
+
+func (ta *TransactionWithAuth) MinerSCSharderSettings(info *MinerSCMinerInfo) (
+	err error) {
+
+	err = ta.t.createSmartContractTxn(MinerSmartContractAddress,
+		transaction.MINERSC_SHARDER_SETTINGS, info, 0)
 	if err != nil {
 		Logger.Error(err)
 		return


### PR DESCRIPTION
Split update_settings into update_miner_settings and update_sharder_settings. New endpoints defined in https://github.com/0chain/0chain/pull/482

Requires https://github.com/0chain/0chain/pull/482 and needed for https://github.com/0chain/zwalletcli/pull/38.