### PR TITLE
Hotfix Temp path for all methods

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -294,38 +294,39 @@ func (a *Allocation) UpdateFileWithThumbnail(localpath string, remotepath string
 }
 
 // UploadFileWithThumbnail [Deprecated]please use CreateChunkedUpload
-func (a *Allocation) UploadFileWithThumbnail(localpath string,
+func (a *Allocation) UploadFileWithThumbnail(tmpPath string, localpath string,
 	remotepath string, thumbnailpath string, attrs fileref.Attributes,
 	status StatusCallback) error {
 
-	return a.StartChunkedUpload(getHomeDir(), localpath, remotepath, status, false,
+	return a.StartChunkedUpload(tmpPath, localpath, remotepath, status, false,
 		thumbnailpath, false, attrs)
 }
 
 // EncryptAndUpdateFile [Deprecated]please use CreateChunkedUpload
-func (a *Allocation) EncryptAndUpdateFile(localpath string, remotepath string,
+func (a *Allocation) EncryptAndUpdateFile(tmpPath string, localpath string, remotepath string,
 	attrs fileref.Attributes, status StatusCallback) error {
 
-	return a.StartChunkedUpload(getHomeDir(), localpath, remotepath, status, true, "", true, attrs)
+	return a.StartChunkedUpload(tmpPath, localpath, remotepath, status, true, "", true, attrs)
 }
 
 // EncryptAndUploadFile [Deprecated]please use CreateChunkedUpload
-func (a *Allocation) EncryptAndUploadFile(localpath string, remotepath string,
+func (a *Allocation) EncryptAndUploadFile(tmpPath string, localpath string, remotepath string,
 	attrs fileref.Attributes, status StatusCallback) error {
 
-	return a.StartChunkedUpload(getHomeDir(), localpath, remotepath, status, false, "", true, attrs)
+	return a.StartChunkedUpload(tmpPath, localpath, remotepath, status, false, "", true, attrs)
 }
 
 // EncryptAndUpdateFileWithThumbnail [Deprecated]please use CreateChunkedUpload
-func (a *Allocation) EncryptAndUpdateFileWithThumbnail(localpath string,
+func (a *Allocation) EncryptAndUpdateFileWithThumbnail(tmpPath string, localpath string,
 	remotepath string, thumbnailpath string, attrs fileref.Attributes, status StatusCallback) error {
 
-	return a.StartChunkedUpload(getHomeDir(), localpath, remotepath, status, true,
+	return a.StartChunkedUpload(tmpPath, localpath, remotepath, status, true,
 		thumbnailpath, true, attrs)
 }
 
 // EncryptAndUploadFileWithThumbnail [Deprecated]please use CreateChunkedUpload
 func (a *Allocation) EncryptAndUploadFileWithThumbnail(
+	tmpPath string,
 	localpath string,
 	remotepath string,
 	thumbnailpath string,
@@ -333,7 +334,7 @@ func (a *Allocation) EncryptAndUploadFileWithThumbnail(
 	status StatusCallback,
 ) error {
 
-	return a.StartChunkedUpload(getHomeDir(),
+	return a.StartChunkedUpload(tmpPath,
 		localpath,
 		remotepath,
 		status,

--- a/zboxcore/sdk/allocation_file_test.go
+++ b/zboxcore/sdk/allocation_file_test.go
@@ -144,6 +144,7 @@ func TestAllocation_UpdateFileWithThumbnail(t *testing.T) {
 
 func TestAllocation_UploadFileWithThumbnail(t *testing.T) {
 	const (
+		mockTmpPath       = "/tmp"
 		mockLocalPath     = "1.txt"
 		mockThumbnailPath = "thumbnail_alloc"
 	)
@@ -165,12 +166,15 @@ func TestAllocation_UploadFileWithThumbnail(t *testing.T) {
 			Baseurl: server.URL,
 		})
 	}
-	err := a.UploadFileWithThumbnail(mockLocalPath, "/", mockThumbnailPath, fileref.Attributes{}, nil)
+	err := a.UploadFileWithThumbnail(mockTmpPath, mockLocalPath, "/", mockThumbnailPath, fileref.Attributes{}, nil)
 	require.NoErrorf(err, "Unexpected error %v", err)
 }
 
 func TestAllocation_EncryptAndUpdateFile(t *testing.T) {
-	const mockLocalPath = "1.txt"
+	const (
+		mockLocalPath = "1.txt"
+		mockTmpPath   = "/tmp"
+	)
 	require := require.New(t)
 	if teardown := setupMockFile(t, mockLocalPath); teardown != nil {
 		defer teardown(t)
@@ -190,12 +194,15 @@ func TestAllocation_EncryptAndUpdateFile(t *testing.T) {
 			Baseurl: server.URL,
 		})
 	}
-	err := a.EncryptAndUpdateFile(mockLocalPath, "/", fileref.Attributes{}, nil)
+	err := a.EncryptAndUpdateFile(mockTmpPath, mockLocalPath, "/", fileref.Attributes{}, nil)
 	require.NoErrorf(err, "Unexpected error %v", err)
 }
 
 func TestAllocation_EncryptAndUploadFile(t *testing.T) {
-	const mockLocalPath = "1.txt"
+	const (
+		mockLocalPath = "1.txt"
+		mockTmpPath   = "/tmp"
+	)
 	require := require.New(t)
 	if teardown := setupMockFile(t, mockLocalPath); teardown != nil {
 		defer teardown(t)
@@ -214,7 +221,7 @@ func TestAllocation_EncryptAndUploadFile(t *testing.T) {
 			Baseurl: server.URL,
 		})
 	}
-	err := a.EncryptAndUploadFile(mockLocalPath, "/", fileref.Attributes{}, nil)
+	err := a.EncryptAndUploadFile(mockTmpPath, mockLocalPath, "/", fileref.Attributes{}, nil)
 	require.NoErrorf(err, "Unexpected error %v", err)
 }
 
@@ -222,6 +229,7 @@ func TestAllocation_EncryptAndUpdateFileWithThumbnail(t *testing.T) {
 	const (
 		mockLocalPath     = "1.txt"
 		mockThumbnailPath = "thumbnail_alloc"
+		mockTmpPath       = "/tmp"
 	)
 	require := require.New(t)
 	if teardown := setupMockFile(t, mockLocalPath); teardown != nil {
@@ -241,7 +249,7 @@ func TestAllocation_EncryptAndUpdateFileWithThumbnail(t *testing.T) {
 			Baseurl: server.URL,
 		})
 	}
-	err := a.EncryptAndUpdateFileWithThumbnail(mockLocalPath, "/", mockThumbnailPath, fileref.Attributes{}, nil)
+	err := a.EncryptAndUpdateFileWithThumbnail(mockTmpPath, mockLocalPath, "/", mockThumbnailPath, fileref.Attributes{}, nil)
 	require.NoErrorf(err, "Unexpected error %v", err)
 }
 
@@ -249,6 +257,7 @@ func TestAllocation_EncryptAndUploadFileWithThumbnail(t *testing.T) {
 	const (
 		mockLocalPath     = "1.txt"
 		mockThumbnailPath = "thumbnail_alloc"
+		mockTmpPath       = "/tmp"
 	)
 	require := require.New(t)
 	if teardown := setupMockFile(t, mockLocalPath); teardown != nil {
@@ -268,7 +277,7 @@ func TestAllocation_EncryptAndUploadFileWithThumbnail(t *testing.T) {
 			Baseurl: server.URL,
 		})
 	}
-	err := a.EncryptAndUploadFileWithThumbnail(mockLocalPath, "/", mockThumbnailPath, fileref.Attributes{}, nil)
+	err := a.EncryptAndUploadFileWithThumbnail(mockTmpPath, mockLocalPath, "/", mockThumbnailPath, fileref.Attributes{}, nil)
 	require.NoErrorf(err, "Unexpected error %v", err)
 }
 


### PR DESCRIPTION
We need explicitly set temp path on clients. Consider to move it to config, as for now it's in methods