### PR TITLE
Client verification header in blobber request for file meta

### DIFF
--- a/constants/context_key.go
+++ b/constants/context_key.go
@@ -6,6 +6,8 @@ type ContextKey string
 const (
 	// ContextKeyAllocation
 	ContextKeyAllocation ContextKey = "allocation"
+	// ContextKeyAllocationObject
+	ContextKeyAllocationObject ContextKey = "allocation_object"
 	// ContextKeyClient
 	ContextKeyClient ContextKey = "client"
 	// ContextKeyClientKey

--- a/zboxcore/zboxutil/http.go
+++ b/zboxcore/zboxutil/http.go
@@ -349,7 +349,10 @@ func NewFileMetaRequest(baseUrl string, allocation string, body io.Reader) (*htt
 	if err != nil {
 		return nil, err
 	}
-	setClientInfo(req)
+	err = setClientInfoWithSign(req, allocation)
+	if err != nil {
+		return nil, err
+	}
 	return req, nil
 }
 


### PR DESCRIPTION
This PR is related to https://github.com/0chain/blobber/issues/327 and contains non-blocking changes:

- The header simply passes client signature in the request header that is made to blobber to get file meta.
- The context constant `ContextKeyAllocationObject` is used to pass down verified allocation object via context (in blobber)