### PR TITLE
Update allocaiont, dont set ower to client

### DIFF
--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -908,7 +908,6 @@ func UpdateAllocation(size int64, expiry int64, allocationID string,
 	}
 
 	updateAllocationRequest := make(map[string]interface{})
-	updateAllocationRequest["owner_id"] = client.GetClientID()
 	updateAllocationRequest["id"] = allocationID
 	updateAllocationRequest["size"] = size
 	updateAllocationRequest["expiration_date"] = expiry


### PR DESCRIPTION
Update allocation does not need to be sent by the allocation's owner as of PR620 https://github.com/0chain/0chain/pull/620 so stop GoSDK setting owner to the client.