### PR TITLE
fix MCL_DIR to use pwd in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,6 @@ install-herumi-ubuntu:
         mv bls* bls && \
         make -C mcl -j $(nproc) lib/libmclbn256.so install && \
         cp mcl/lib/libmclbn256.so /usr/local/lib && \
-        make MCL_DIR=../mcl -C bls -j $(nproc) install && \
+        make MCL_DIR=$(shell pwd)/mcl -C bls -j $(nproc) install && \
         rm -R /tmp/mcl && \
         rm -R /tmp/bls

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,6 @@ install-herumi-ubuntu:
         mv bls* bls && \
         make -C mcl -j $(nproc) lib/libmclbn256.so install && \
         cp mcl/lib/libmclbn256.so /usr/local/lib && \
-        make MCL_DIR=$(shell pwd)/mcl -C bls -j $(nproc) install && \
+        make MCL_DIR=/tmp/mcl -C bls -j $(nproc) install && \
         rm -R /tmp/mcl && \
         rm -R /tmp/bls


### PR DESCRIPTION
Herumi installation sometimes caused an error when we use makefile. As per https://github.com/herumi/bls/issues/33, we just need to use `pwd` instead of `..`. I have come across this error in other repo and this fixes it.