### PR TITLE
Create dir error handling

### DIFF
--- a/core/zcncrypto/bls0chain_test.go
+++ b/core/zcncrypto/bls0chain_test.go
@@ -4,7 +4,6 @@
 package zcncrypto
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/herumi/bls-go-binary/bls"
@@ -49,8 +48,6 @@ func TestSignAndVerify(t *testing.T) {
 	var pk1 bls.PublicKey
 
 	pk1.DeserializeHexStr(pk)
-
-	fmt.Println(pk1.GetHexString())
 
 	require.NoError(t, err)
 

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b
 	golang.org/x/net v0.0.0-20211123203042-d83791d6bcd9 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -490,7 +490,7 @@ func TestAllocation_CreateDir(t *testing.T) {
 	mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
 		return strings.HasPrefix(req.URL.Path, "TestAllocation_CreateDir")
 	})).Return(&http.Response{
-		StatusCode: http.StatusBadRequest,
+		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
 	}, nil)
 

--- a/zboxcore/sdk/dirworker.go
+++ b/zboxcore/sdk/dirworker.go
@@ -54,7 +54,7 @@ func (req *DirRequest) createDirInBlobber(blobber *blockchain.StorageNode) error
 	body := new(bytes.Buffer)
 	formWriter := multipart.NewWriter(body)
 	formWriter.WriteField("connection_id", req.connectionID)
-	formWriter.WriteField("dir_path", filepath.Join("/", req.name))
+	formWriter.WriteField("dir_path", filepath.ToSlash(filepath.Join("/", req.name)))
 	formWriter.Close()
 	httpreq, err := zboxutil.NewCreateDirRequest(blobber.Baseurl, req.allocationID, body)
 	if err != nil {

--- a/zboxcore/sdk/dirworker.go
+++ b/zboxcore/sdk/dirworker.go
@@ -62,10 +62,7 @@ func (req *DirRequest) createDirInBlobber(blobber *blockchain.StorageNode) error
 	formWriter := multipart.NewWriter(body)
 	formWriter.WriteField("connection_id", req.connectionID)
 
-	dirPath := filepath.ToSlash(req.name)
-	if !strings.HasPrefix(dirPath, "/") {
-		dirPath = filepath.Join("/", dirPath)
-	}
+	dirPath := filepath.Join("/", filepath.ToSlash(req.name))
 	formWriter.WriteField("dir_path", dirPath)
 
 	formWriter.Close()


### PR DESCRIPTION
Description:

- Use of errorGroups for error propagation if creating a directory is not successful. Earlier nil was returned, now:
  - 101 char dirname returns the error: `CreateDir failed:  {"error":"ERROR: value too long for type character varying(100) (SQLSTATE 22001)"}`
  - Duplicate file returns the error: `CreateDir failed:  {"code":"duplicate_file","error":"duplicate_file: File at path already exists"}`
  - createdir on non-owned allocation gives: `CreateDir failed:  {"code":"invalid_signature","error":"invalid_signature: Invalid signature"}`
so on.

Zboxcli using this gosdk passes all tests: https://github.com/0chain/zboxcli/runs/4713474416?check_suite_focus=true

Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/blobber/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master BEFORE merging this PR

Associated PRs (Link as appropriate):
- https://github.com/0chain/zboxcli/pull/152
- https://github.com/0chain/system_test/pull/153