### PR TITLE
Enhancement: add error handling in zcncrypto to prevent panic

### DIFF
--- a/core/zcncrypto/bls.go
+++ b/core/zcncrypto/bls.go
@@ -38,7 +38,7 @@ type SecretKey interface {
 	Sign(m string) Signature
 	Add(rhs SecretKey)
 
-	GetMasterSecretKey(k int) (msk []SecretKey)
+	GetMasterSecretKey(k int) (msk []SecretKey, err error)
 	Set(msk []SecretKey, id ID) error
 }
 

--- a/core/zcncrypto/bls_herumi.go
+++ b/core/zcncrypto/bls_herumi.go
@@ -118,7 +118,11 @@ func (sk *herumiSecretKey) Sign(m string) Signature {
 	}
 }
 
-func (sk *herumiSecretKey) GetMasterSecretKey(k int) []SecretKey {
+func (sk *herumiSecretKey) GetMasterSecretKey(k int) ([]SecretKey, error) {
+	if k < 1 {
+		return nil, errors.New("cannot get master secret key for threshold less than 1")
+	}
+
 	list := sk.SecretKey.GetMasterSecretKey(k)
 
 	msk := make([]SecretKey, len(list))
@@ -128,7 +132,7 @@ func (sk *herumiSecretKey) GetMasterSecretKey(k int) []SecretKey {
 
 	}
 
-	return msk
+	return msk, nil
 }
 
 func (sk *herumiSecretKey) Set(msk []SecretKey, id ID) error {

--- a/core/zcncrypto/factory.go
+++ b/core/zcncrypto/factory.go
@@ -64,7 +64,6 @@ func UnmarshalSignatureSchemes(sigScheme string, obj interface{}) ([]SignatureSc
 
 //GenerateThresholdKeyShares given a signature scheme will generate threshold sig keys
 func GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]SignatureScheme, error) {
-
 	b0ss, ok := originalKey.(*HerumiScheme)
 	if !ok {
 		return nil, errors.New("bls0_generate_threshold_key_shares", "Invalid encryption scheme")
@@ -81,7 +80,10 @@ func GenerateThresholdKeyShares(t, n int, originalKey SignatureScheme) ([]Signat
 		return nil, err
 	}
 
-	polynomial := b0original.GetMasterSecretKey(t)
+	polynomial, err := b0original.GetMasterSecretKey(t)
+	if err != nil {
+		return nil, err
+	}
 
 	var shares []SignatureScheme
 	for i := 1; i <= n; i++ {

--- a/zcncore/mswallet.go
+++ b/zcncore/mswallet.go
@@ -115,11 +115,8 @@ type MSVoteCallback interface {
 
 // CreateMSWallet returns multisig wallet information
 func CreateMSWallet(t, n int) (string, string, []string, error) {
-	if t > n {
-		return "", "", nil, errors.Newf("", fmt.Sprintf("Error: given threshold (%d) is too high. Threshold has to be less than or equal to numsigners (%d)\n", t, n))
-	}
-	if t <= 0 {
-		return "", "", nil, errors.Newf("", "Error: threshold should be bigger than 0")
+	if t < 1 || t > n {
+		return "", "", nil, errors.New("bls0_generate_threshold_key_shares", fmt.Sprintf("Given threshold (%d) is less than 1 or greater than numsigners (%d)", t, n))
 	}
 
 	id := 0


### PR DESCRIPTION
### Changes
- Though #405 fixed the issue of [zwallet panicking for 0 threshold in multisig wallet](https://github.com/0chain/zwalletcli/issues/49), it is masking the root cause of the panic. Since `GenerateThresholdKeyShares` and `GetMasterSecretKey` are reusable we can see the same issue elsewhere. This PR adds appropriate error handling in core/zcncrypto package to prevent the same in future.

### Tests
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [x]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [x]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber: N/A
- 0chain: N/A
- system_test: N/A
- zboxcli: N/A
- zwalletcli: N/A
- Other: ...
