### PR TITLE
fix(zcncore): updated StakePoolSettings

### DIFF
--- a/zcncore/transaction.go
+++ b/zcncore/transaction.go
@@ -1709,10 +1709,16 @@ func (t *Transaction) StakePoolUnlock(blobberID, poolID string,
 }
 
 type StakePoolSettings struct {
-	DelegateWallet string         `json:"delegate_wallet"`
-	MinStake       common.Balance `json:"min_stake"`
-	MaxStake       common.Balance `json:"max_stake"`
-	NumDelegates   int            `json:"num_delegates"`
+	// DelegateWallet for pool owner.
+	DelegateWallet string `json:"delegate_wallet"`
+	// MinStake allowed.
+	MinStake common.Balance `json:"min_stake"`
+	// MaxStake allowed.
+	MaxStake common.Balance `json:"max_stake"`
+	// NumDelegates maximum allowed.
+	NumDelegates int `json:"num_delegates"`
+	// ServiceCharge is blobber service charge.
+	ServiceCharge float64 `json:"service_charge"`
 }
 
 type Terms struct {


### PR DESCRIPTION
### Changes
-

### Fixes
- used zcncore.GetBlobber instead sdk.GetBlobber. Because sdk.GetBlobber is designed for client. and zboxcore.InitStorageSDK must be invoked. it doesn't work for blobber

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber: https://github.com/0chain/blobber/pull/666
- gosdk: https://github.com/0chain/gosdk/pull/445
