### PR TITLE
fix createdir for windows

### DIFF
--- a/zboxcore/sdk/dirworker.go
+++ b/zboxcore/sdk/dirworker.go
@@ -62,7 +62,7 @@ func (req *DirRequest) createDirInBlobber(blobber *blockchain.StorageNode) error
 	formWriter := multipart.NewWriter(body)
 	formWriter.WriteField("connection_id", req.connectionID)
 
-	dirPath := filepath.Join("/", filepath.ToSlash(req.name))
+	dirPath := filepath.ToSlash(filepath.Join("/", req.name))
 	formWriter.WriteField("dir_path", dirPath)
 
 	formWriter.Close()


### PR DESCRIPTION
### Changes
- Calls `filepath.ToSlash()` on final joined dirpath, as opposed to calling it on req.name and then joining with a `/`.

### Fixes
- https://github.com/0chain/gosdk/issues/392

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
