### PR TITLE
Indefinitely request blobber for lock exists error

### DIFF
--- a/zboxcore/sdk/blockdownloadworker.go
+++ b/zboxcore/sdk/blockdownloadworker.go
@@ -19,6 +19,11 @@ import (
 	"github.com/0chain/gosdk/zboxcore/zboxutil"
 )
 
+const (
+	NotEnoughTokens = "not_enough_tokens"
+	LockExists      = "LockExists"
+)
+
 type BlockDownloadRequest struct {
 	blobber            *blockchain.StorageNode
 	allocationID       string
@@ -187,11 +192,17 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 
 				}
 
-				if bytes.Contains(respBody, []byte("not_enough_tokens")) {
+				if bytes.Contains(respBody, []byte(NotEnoughTokens)) {
 					shouldRetry, retry = false, 3 // don't repeat
 					req.blobber.SetSkip(true)
-					return errors.New("not_enough_tokens", "")
+					return errors.New(NotEnoughTokens, "")
 				}
+
+				if bytes.Contains(respBody, []byte(LockExists)) {
+					shouldRetry = true
+					return errors.New(LockExists, string(respBody))
+				}
+
 				return errors.New("response_error", string(respBody))
 			}
 

--- a/zboxcore/sdk/blockdownloadworker.go
+++ b/zboxcore/sdk/blockdownloadworker.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	NotEnoughTokens = "not_enough_tokens"
-	LockExists      = "LockExists"
+	LockExists      = "lock_exists"
 )
 
 type BlockDownloadRequest struct {
@@ -199,6 +199,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 				}
 
 				if bytes.Contains(respBody, []byte(LockExists)) {
+					zlogger.Logger.Debug("Lock exists error.")
 					shouldRetry = true
 					return errors.New(LockExists, string(respBody))
 				}
@@ -229,6 +230,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 			if shouldRetry {
 				retry = 0
 				shouldRetry = false
+				zlogger.Logger.Debug("Retrying for Error occurred: ", err)
 				continue
 			}
 			if retry >= 3 {

--- a/zboxcore/sdk/filemetaworker.go
+++ b/zboxcore/sdk/filemetaworker.go
@@ -71,6 +71,7 @@ func (req *ListRequest) getFileMetaInfoFromBlobber(blobber *blockchain.StorageNo
 			return errors.Wrap(err, "Error: Resp")
 		}
 		l.Logger.Info("File Meta result:", string(resp_body))
+		l.Logger.Debug("File meta response status: ", resp.Status)
 		s.WriteString(string(resp_body))
 		if resp.StatusCode == http.StatusOK {
 			err = json.Unmarshal(resp_body, &fileRef)


### PR DESCRIPTION
### Fixes
- Make indefinite request to blobber as long as it returns `lock_exists` error

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
