### PR TITLE
Use 200 if it is tied with some other status

### DIFF
--- a/zcncore/transaction_query.go
+++ b/zcncore/transaction_query.go
@@ -243,7 +243,13 @@ func (tq *TransactionQuery) GetInfo(ctx context.Context, query string) (*QueryRe
 			}
 
 			consensuses[qr.StatusCode]++
-			if consensuses[qr.StatusCode] >= maxConsensus {
+			if consensuses[qr.StatusCode] > maxConsensus {
+				maxConsensus = consensuses[qr.StatusCode]
+				consensusesResp = qr
+			}
+
+			// If number of 200's is equal to number of some other status codes, use 200's.
+			if qr.StatusCode == http.StatusOK && consensuses[qr.StatusCode] == maxConsensus {
 				maxConsensus = consensuses[qr.StatusCode]
 				consensusesResp = qr
 			}


### PR DESCRIPTION
### Changes
- Uses 200 if it is tied with some other status for dominant response from sharders.

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
