### PR TITLE
fix: read pool depletion issue

### DIFF
--- a/zboxcore/sdk/blockdownloadworker.go
+++ b/zboxcore/sdk/blockdownloadworker.go
@@ -224,7 +224,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 				rspData.BlockChunks = req.splitData(respBody, req.chunkSize)
 			}
 
-			incBlobberReadCtr(req.allocationID, req.blobber.ID, lastBlobberReadCounter+req.numBlocks)
+			incBlobberReadCtr(req.allocationID, req.blobber.ID, req.numBlocks)
 			req.result <- &rspData
 			return nil
 		})


### PR DESCRIPTION
### Changes

fixes exponential ReadPool token depletion issue. 
This happens because there was an exponential increase in read counter. 


### Fixes

https://github.com/0chain/0chain/issues/1697

https://github.com/0chain/gosdk/blob/480e8fbbda63b6791e7ab72668e5d3045242411d/zboxcore/sdk/read_counter_ctr.go#L32-L37

inside the `incBlobberReadCtr` function we are already adding the `lastBlobberReadCounter` so we can simply pass `req.numBlocks` which signifies the value the read counter should be incremented.

### Tests

tested this by checking in events DB:

previously the grown of the read counter is:
```
events_db=# select read_counter,read_size from read_markers where allocation_id='682dfc7e374fb18d54ca89bb33879227cd1bab2278f578705e6b10970dbab325';
 read_counter |     read_size     
--------------+-------------------
           10 |   0.0006103515625
           10 |   0.0006103515625
           20 |   0.0006103515625
           30 |    0.001220703125
           40 |    0.001220703125
           50 |    0.001220703125
           60 |    0.001220703125
           80 |   0.0018310546875
           80 |    0.001220703125
          100 |    0.001220703125
          100 |    0.001220703125
          440 |    0.020751953125
          880 |    0.047607421875
         7120 |     0.40771484375
        57040 |       3.427734375
       114100 |    6.529541015625
       456400 |            24.375
       456410 |   0.0006103515625
       456400 |   20.892333984375
      3651280 |               195
      3651360 | 195.0042724609375
      7302740 |  222.862548828125
      7302580 |  222.857666015625
```

after this fix the read counter just increments by the no of blocks downloaded

```
vents_db=# select read_counter,read_size from read_markers where allocation_id='bebe3a165ad0d638701a871b441bf10e4b60ceb981c9fe94851b6148f2c53136';
 read_counter |    read_size    
--------------+-----------------
           80 |    0.0048828125
           80 |    0.0048828125
          110 | 0.0018310546875
          120 |   0.00244140625
          120 | 0.0006103515625
          160 |   0.00244140625
          190 | 0.0042724609375
          200 |   0.00244140625
          200 | 0.0006103515625
          240 |   0.00244140625
          240 |   0.00244140625
          280 |   0.00244140625
          320 |    0.0048828125
          320 |   0.00244140625
          370 | 0.0030517578125
(15 rows)
```





Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
