### PR TITLE
use getConsensus() function

### DIFF
--- a/zboxcore/sdk/chunked_upload.go
+++ b/zboxcore/sdk/chunked_upload.go
@@ -560,7 +560,7 @@ func (su *ChunkedUpload) processUpload(chunkStartIndex, chunkEndIndex int,
 			defer wg.Done()
 			err = b.sendUploadRequest(ctx, su, chunkEndIndex, isFinal, encryptedKey, body, formData, pos)
 			if err != nil {
-				logger.Logger.Error(err)
+				logger.Logger.Error("error during sendUploadRequest", err)
 			}
 		}(blobber, body, formData, pos)
 	}
@@ -569,7 +569,7 @@ func (su *ChunkedUpload) processUpload(chunkStartIndex, chunkEndIndex int,
 
 	if !su.consensus.isConsensusOk() {
 		return thrown.New("consensus_not_met", fmt.Sprintf("Upload failed. Required consensus atleast %d, got %d",
-			su.consensus.consensusThresh, su.consensus.consensus))
+			su.consensus.consensusThresh, su.consensus.getConsensus()))
 	}
 
 	return nil

--- a/zboxcore/sdk/chunked_upload_blobber.go
+++ b/zboxcore/sdk/chunked_upload_blobber.go
@@ -133,7 +133,7 @@ func (sb *ChunkedUploadBlobber) sendUploadRequest(
 
 			err = json.Unmarshal(respbody, &r)
 			if err != nil {
-				logger.Logger.Error(sb.blobber.Baseurl, " Upload response parse error: ", err)
+				logger.Logger.Error(sb.blobber.Baseurl, "Upload response parse error: ", err)
 				return
 			}
 			if r.Filename != su.fileMeta.RemoteName || r.Hash != formData.ChunkHash {
@@ -162,7 +162,7 @@ func (sb *ChunkedUploadBlobber) sendUploadRequest(
 			sb.fileRef.ActualThumbnailHash = su.fileMeta.ActualThumbnailHash
 		}
 
-		//fixed fileRef in last chunk on stream
+		// fixed fileRef in last chunk on stream
 		if isFinal {
 			sb.fileRef.MerkleRoot = formData.ChallengeHash
 			sb.fileRef.ContentHash = formData.ContentHash

--- a/zboxcore/zboxutil/http.go
+++ b/zboxcore/zboxutil/http.go
@@ -425,7 +425,7 @@ func NewListRequest(baseUrl, allocation string, path, pathHash string, auth_toke
 	return req, nil
 }
 
-// NewUploadRequestWithMethod create a http reqeust of upload
+// NewUploadRequestWithMethod create a http request of upload
 func NewUploadRequestWithMethod(baseURL, allocation string, body io.Reader, method string) (*http.Request, error) {
 	u, err := joinUrl(baseURL, UPLOAD_ENDPOINT, allocation)
 	if err != nil {
@@ -440,6 +440,7 @@ func NewUploadRequestWithMethod(baseURL, allocation string, body io.Reader, meth
 		return nil, err
 	}
 
+	// set header: X-App-Client-Signature
 	if err := setClientInfoWithSign(req, allocation); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Changes
consensus.consensus is a shared variable. This variable should be accessed using `getConsensus()` so using this function.

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
