### PR TITLE
make blobber ID mandatory in sdk.GetStakePoolInfo

### DIFF
--- a/zboxcore/sdk/sdk.go
+++ b/zboxcore/sdk/sdk.go
@@ -285,7 +285,7 @@ func GetStakePoolInfo(blobberID string) (info *StakePoolInfo, err error) {
 		return nil, sdkNotInitialized
 	}
 	if blobberID == "" {
-		blobberID = client.GetClientID()
+		return nil, errors.New("", "blobber_id is required")
 	}
 
 	var b []byte


### PR DESCRIPTION
### Changes

blobber_id field is actually mandatory for sp-info. But if I dont provide any blobber, it takes client ID as default blobber_id. This is incorrect. Since blobber_id is necessary, we should take it from command line arguments.

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli: https://github.com/0chain/zboxcli/pull/307
- zwalletcli:
- Other: ...
