### PR TITLE
use getConsensus() to show the value of consensus

### DIFF
--- a/mobilesdk/zbox/util.go
+++ b/mobilesdk/zbox/util.go
@@ -92,7 +92,7 @@ func Sign(hash string) (string, error) {
 	return client.Sign(hash)
 }
 
-// VerifySignature - verify message with signature
+// VerifySignatxure - verify message with signature
 func VerifySignature(signature string, msg string) (bool, error) {
 	return client.VerifySignature(signature, msg)
 }

--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -692,8 +692,8 @@ func (a *Allocation) ListDir(path string) (*ListResult, error) {
 	return nil, errors.New("list_request_failed", "Failed to get list response from the blobbers")
 }
 
-//This function will retrieve paginated objectTree and will handle concensus; Required tree should be made in application side.
-//TODO use allocation context
+// This function will retrieve paginated objectTree and will handle concensus; Required tree should be made in application side.
+// TODO use allocation context
 func (a *Allocation) GetRefs(path, offsetPath, updatedDate, offsetDate, fileType, refType string, level, pageLimit int) (*ObjectTreeResult, error) {
 	if len(path) == 0 || !zboxutil.IsRemoteAbs(path) {
 		return nil, errors.New("invalid_path", fmt.Sprintf("Absolute path required. Path provided: %v", path))

--- a/zboxcore/sdk/chunked_upload.go
+++ b/zboxcore/sdk/chunked_upload.go
@@ -632,13 +632,14 @@ func (su *ChunkedUpload) processCommit() error {
 	wg.Wait()
 
 	if !su.consensus.isConsensusOk() {
+		consensus := su.consensus.getConsensus()
 		err := thrown.New("consensus_not_met",
 			fmt.Sprintf("Upload commit failed. Required consensus atleast %d, got %d",
-				su.consensus.consensusThresh, su.consensus.consensus))
+				su.consensus.consensusThresh, consensus))
 
-		if su.consensus.getConsensus() != 0 {
+		if consensus != 0 {
 			logger.Logger.Info("Commit consensus failed, Deleting remote file....")
-			su.allocationObj.deleteFile(su.fileMeta.RemotePath, su.consensus.getConsensus(), su.consensus.getConsensus()) //nolint
+			su.allocationObj.deleteFile(su.fileMeta.RemotePath, consensus, consensus) //nolint
 		}
 		if su.statusCallback != nil {
 			su.statusCallback.Error(su.allocationObj.ID, su.fileMeta.RemotePath, su.opCode, err)

--- a/zboxcore/sdk/chunked_upload_blobber.go
+++ b/zboxcore/sdk/chunked_upload_blobber.go
@@ -244,7 +244,7 @@ func (sb *ChunkedUploadBlobber) processCommit(ctx context.Context, su *ChunkedUp
 	}
 	req.Header.Add("Content-Type", formWriter.FormDataContentType())
 
-	logger.Logger.Info("Committing to blobber." + sb.blobber.Baseurl)
+	logger.Logger.Info("Committing to blobber. " + sb.blobber.Baseurl)
 
 	var (
 		resp           *http.Response

--- a/zboxcore/sdk/consensus.go
+++ b/zboxcore/sdk/consensus.go
@@ -42,5 +42,5 @@ func (c *Consensus) isConsensusOk() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return (c.getConsensus() >= c.consensusThresh)
+	return c.getConsensus() >= c.consensusThresh
 }

--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -196,7 +196,7 @@ func (req *DeleteRequest) ProcessDelete() (err error) {
 	if !req.consensus.isConsensusOk() {
 		return errors.New("consensus_not_met",
 			fmt.Sprintf("Consensus on delete failed. Required consensus %d got %d",
-				req.consensus.consensusThresh, req.consensus.consensus))
+				req.consensus.consensusThresh, req.consensus.getConsensus()))
 	}
 
 	writeMarkerMutex, err := CreateWriteMarkerMutex(client.GetClient(), req.allocationObj)
@@ -256,7 +256,7 @@ func (req *DeleteRequest) ProcessDelete() (err error) {
 	if !req.consensus.isConsensusOk() {
 		return errors.New("consensus_not_met",
 			fmt.Sprintf("Consensus on commit not met. Required %d, got %d",
-				req.consensus.consensusThresh, req.consensus.consensus))
+				req.consensus.consensusThresh, req.consensus.getConsensus()))
 	}
 	return nil
 }

--- a/zboxcore/sdk/renameworker.go
+++ b/zboxcore/sdk/renameworker.go
@@ -166,7 +166,7 @@ func (req *RenameRequest) ProcessRename() error {
 	if !req.consensus.isConsensusOk() {
 		return errors.New("consensus_not_met",
 			fmt.Sprintf("Rename failed. Required consensus %d got %d",
-				req.consensus.consensusThresh, req.consensus.consensus))
+				req.consensus.consensusThresh, req.consensus.getConsensus()))
 	}
 
 	writeMarkerMutex, err := CreateWriteMarkerMutex(client.GetClient(), req.allocationObj)

--- a/zboxcore/sdk/writemarker_mutex.go
+++ b/zboxcore/sdk/writemarker_mutex.go
@@ -199,7 +199,7 @@ func (wmMu *WriteMarkerMutex) Lock(
 
 		return errors.New("lock_consensus_not_met",
 			fmt.Sprintf("Required consensus %d got %d",
-				consensus.consensusThresh, consensus.consensus))
+				consensus.consensusThresh, consensus.getConsensus()))
 	}
 
 	return nil


### PR DESCRIPTION
### Changes
In the during the loadTest where a lot of concurrent request happens, using `getConsensus()` function to show the value of current consensus helps better evaluation

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
