### PR TITLE
changed stake-poolLock to use provide

### DIFF
--- a/mobilesdk/zcncore/transaction.go
+++ b/mobilesdk/zcncore/transaction.go
@@ -174,8 +174,8 @@ type TransactionScheme interface {
 	CreateReadPool(fee uint64) error
 	ReadPoolLock(allocID string, blobberID string, duration int64, lock uint64, fee uint64) error
 	ReadPoolUnlock(poolID string, fee uint64) error
-	StakePoolLock(blobberID string, lock uint64, fee uint64) error
-	StakePoolUnlock(blobberID string, poolID string, fee uint64) error
+	StakePoolLock(providerId string, providerType int, lock uint64, fee uint64) error
+	StakePoolUnlock(providerId string, providerType int, fee uint64) error
 	UpdateBlobberSettings(blobber *Blobber, fee uint64) error
 	UpdateValidatorSettings(validator *Validator, fee uint64) error
 	UpdateAllocation(allocID string, sizeDiff int64, expirationDiff int64, lock uint64, fee uint64) error
@@ -1670,15 +1670,18 @@ func (t *Transaction) ReadPoolUnlock(poolID string, fee uint64) (err error) {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (t *Transaction) StakePoolLock(blobberID string, lock, fee uint64) (
+func (t *Transaction) StakePoolLock(providerId string, providerType int, lock, fee uint64) (
 	err error) {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType int    `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_LOCK, &spr, lock)
@@ -1692,17 +1695,18 @@ func (t *Transaction) StakePoolLock(blobberID string, lock, fee uint64) (
 }
 
 // StakePoolUnlock by blobberID and poolID.
-func (t *Transaction) StakePoolUnlock(blobberID, poolID string,
+func (t *Transaction) StakePoolUnlock(providerId string, providerType int,
 	fee uint64) (err error) {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
-		PoolID    string `json:"pool_id"`
+		ProviderType int    `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
-	spr.PoolID = poolID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = t.createSmartContractTxn(StorageSmartContractAddress, transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)
 	if err != nil {

--- a/mobilesdk/zcncore/transactionauth.go
+++ b/mobilesdk/zcncore/transactionauth.go
@@ -597,15 +597,18 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(poolID string, fee uint64) (
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(blobberID string,
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType int,
 	lock, fee uint64) (err error) {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType int    `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = ta.t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_LOCK, &spr, lock)
@@ -619,17 +622,18 @@ func (ta *TransactionWithAuth) StakePoolLock(blobberID string,
 }
 
 // StakePoolUnlock by blobberID and poolID.
-func (ta *TransactionWithAuth) StakePoolUnlock(blobberID, poolID string,
+func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType int,
 	fee uint64) (err error) {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
-		PoolID    string `json:"pool_id"`
+		ProviderType int    `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
-	spr.PoolID = poolID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = ta.t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)

--- a/zcncore/transaction.go
+++ b/zcncore/transaction.go
@@ -142,7 +142,7 @@ type TransactionCommon interface {
 	ReadPoolLock(allocID string, blobberID string, duration int64, lock uint64, fee uint64) error
 	ReadPoolUnlock(fee uint64) error
 	StakePoolLock(providerId string, providerType Provider, lock uint64, fee uint64) error
-	StakePoolUnlock(blobberID string, fee uint64) error
+	StakePoolUnlock(providerId string, providerType Provider, fee uint64) error
 	UpdateBlobberSettings(blobber *Blobber, fee uint64) error
 	UpdateValidatorSettings(validator *Validator, fee uint64) error
 	UpdateAllocation(allocID string, sizeDiff int64, expirationDiff int64, lock uint64, fee uint64) error
@@ -524,24 +524,26 @@ func (t *Transaction) StakePoolLock(providerId string, providerType Provider, lo
 }
 
 // StakePoolUnlock by blobberID and poolID.
-func (t *Transaction) StakePoolUnlock(blobberID string,
-	fee uint64) (err error) {
+func (t *Transaction) StakePoolUnlock(providerId string, providerType Provider, fee uint64) error {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType Provider `json:"provider_type,omitempty"`
+		ProviderID   string   `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
-	err = t.createSmartContractTxn(StorageSmartContractAddress, transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)
+	err := t.createSmartContractTxn(StorageSmartContractAddress, transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)
 	if err != nil {
 		logging.Error(err)
-		return
+		return err
 	}
 	t.SetTransactionFee(fee)
 	go func() { t.setNonceAndSubmit() }()
-	return
+	return nil
 }
 
 // UpdateBlobberSettings update settings of a blobber.

--- a/zcncore/transaction_mobile.go
+++ b/zcncore/transaction_mobile.go
@@ -48,8 +48,8 @@ type TransactionCommon interface {
 	CreateReadPool(fee string) error
 	ReadPoolLock(allocID string, blobberID string, duration int64, lock, fee string) error
 	ReadPoolUnlock(fee string) error
-	StakePoolLock(blobberID string, lock, fee string) error
-	StakePoolUnlock(blobberID string, fee string) error
+	StakePoolLock(providerId string, providerType int, lock string, fee string) error
+	StakePoolUnlock(providerId string, providerType int, fee string) error
 	UpdateBlobberSettings(blobber Blobber, fee string) error
 	UpdateAllocation(allocID string, sizeDiff int64, expirationDiff int64, lock, fee string) error
 	WritePoolLock(allocID string, lock, fee string) error
@@ -643,7 +643,7 @@ func (t *Transaction) ReadPoolUnlock(fee string) error {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (t *Transaction) StakePoolLock(blobberID string, lock, fee string) error {
+func (t *Transaction) StakePoolLock(providerId string, providerType int, lock, fee string) error {
 	lv, err := parseCoinStr(lock)
 	if err != nil {
 		return err
@@ -655,11 +655,14 @@ func (t *Transaction) StakePoolLock(blobberID string, lock, fee string) error {
 	}
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType int    `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_LOCK, &spr, lv)
@@ -673,18 +676,21 @@ func (t *Transaction) StakePoolLock(blobberID string, lock, fee string) error {
 }
 
 // StakePoolUnlock by blobberID
-func (t *Transaction) StakePoolUnlock(blobberID string, fee string) error {
+func (t *Transaction) StakePoolUnlock(providerId string, providerType int, fee string) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err
 	}
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType int    `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = t.createSmartContractTxn(StorageSmartContractAddress, transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)
 	if err != nil {

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -206,24 +206,27 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Pro
 }
 
 // StakePoolUnlock by blobberID
-func (ta *TransactionWithAuth) StakePoolUnlock(blobberID string, fee uint64) (err error) {
+func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType Provider, fee uint64) error {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType Provider `json:"provider_type,omitempty"`
+		ProviderID   string   `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
-	err = ta.t.createSmartContractTxn(StorageSmartContractAddress,
+	err := ta.t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)
 	if err != nil {
 		logging.Error(err)
-		return
+		return err
 	}
 	ta.t.SetTransactionFee(fee)
 	go func() { ta.submitTxn() }()
-	return
+	return nil
 }
 
 // UpdateBlobberSettings update settings of a blobber.

--- a/zcncore/transactionauth.go
+++ b/zcncore/transactionauth.go
@@ -182,25 +182,27 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(fee uint64) (
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(blobberID string,
-	lock, fee uint64) (err error) {
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Provider, lock uint64, fee uint64) error {
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType Provider `json:"provider_type,omitempty"`
+		ProviderID   string   `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
-	err = ta.t.createSmartContractTxn(StorageSmartContractAddress,
+	err := ta.t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_LOCK, &spr, lock)
 	if err != nil {
 		logging.Error(err)
-		return
+		return err
 	}
 	ta.t.SetTransactionFee(fee)
 	go func() { ta.submitTxn() }()
-	return
+	return nil
 }
 
 // StakePoolUnlock by blobberID

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -230,8 +230,7 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(fee string) error {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(blobberID string,
-	lock, fee string) error {
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uint64, lock uint64, fee uint64) error {
 	lv, err := parseCoinStr(lock)
 	if err != nil {
 		return err
@@ -243,12 +242,14 @@ func (ta *TransactionWithAuth) StakePoolLock(blobberID string,
 	}
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType uint64 `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
-
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 	err = ta.t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_LOCK, &spr, lv)
 	if err != nil {
@@ -353,8 +354,8 @@ func (ta *TransactionWithAuth) WritePoolLock(allocID, lock, fee string) error {
 	}
 
 	var lr = struct {
-		AllocationID string        `json:"allocation_id"`
-	} {
+		AllocationID string `json:"allocation_id"`
+	}{
 		AllocationID: allocID,
 	}
 
@@ -376,9 +377,9 @@ func (ta *TransactionWithAuth) WritePoolUnlock(allocID string, fee string) error
 		return err
 	}
 
-	var ur =  struct {
+	var ur = struct {
 		AllocationID string `json:"allocation_id"`
-	} {
+	}{
 		AllocationID: allocID,
 	}
 

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -243,8 +243,8 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uin
 	}
 
 	type stakePoolRequest struct {
-		ProviderType Provider `json:"provider_type,omitempty"`
-		ProviderID   string   `json:"provider_id,omitempty"`
+		ProviderType uint64 `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
 	spr := stakePoolRequest{
@@ -270,8 +270,8 @@ func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType u
 	}
 
 	type stakePoolRequest struct {
-		ProviderType Provider `json:"provider_type,omitempty"`
-		ProviderID   string   `json:"provider_id,omitempty"`
+		ProviderType uint64 `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
 	spr := stakePoolRequest{

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -230,7 +230,7 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(fee string) error {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uint64,
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType int,
 	lock, fee string) error {
 	lv, err := parseCoinStr(lock)
 	if err != nil {
@@ -263,7 +263,7 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uin
 }
 
 // StakePoolUnlock by blobberID
-func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType uint64, fee string) error {
+func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType int, fee string) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -230,7 +230,7 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(fee string) error {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uint64, lock uint64, fee uint64) error {
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Provider, lock uint64, fee uint64) error {
 	lv, err := parseCoinStr(lock)
 	if err != nil {
 		return err
@@ -242,8 +242,8 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uin
 	}
 
 	type stakePoolRequest struct {
-		ProviderType uint64 `json:"provider_type,omitempty"`
-		ProviderID   string `json:"provider_id,omitempty"`
+		ProviderType Provider `json:"provider_type,omitempty"`
+		ProviderID   string   `json:"provider_id,omitempty"`
 	}
 
 	spr := stakePoolRequest{
@@ -262,15 +262,15 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uin
 }
 
 // StakePoolUnlock by blobberID
-func (ta *Transaction) StakePoolUnlock(providerId string, providerType uint64, fee uint64) error {
+func (ta *Transaction) StakePoolUnlock(providerId string, providerType Provider, fee uint64) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err
 	}
 
 	type stakePoolRequest struct {
-		ProviderType uint64 `json:"provider_type,omitempty"`
-		ProviderID   string `json:"provider_id,omitempty"`
+		ProviderType Provider `json:"provider_type,omitempty"`
+		ProviderID   string   `json:"provider_id,omitempty"`
 	}
 
 	spr := stakePoolRequest{

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -262,7 +262,7 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Pro
 }
 
 // StakePoolUnlock by blobberID
-func (ta *Transaction) StakePoolUnlock(providerId string, providerType Provider, fee uint64) error {
+func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType Provider, fee uint64) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -230,7 +230,7 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(fee string) error {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Provider,
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uint64,
 	lock, fee string) error {
 	lv, err := parseCoinStr(lock)
 	if err != nil {
@@ -263,7 +263,7 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Pro
 }
 
 // StakePoolUnlock by blobberID
-func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType Provider, fee string) error {
+func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType uint64, fee string) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -262,18 +262,21 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType uin
 }
 
 // StakePoolUnlock by blobberID
-func (ta *TransactionWithAuth) StakePoolUnlock(blobberID string, fee string) error {
+func (ta *Transaction) StakePoolUnlock(providerId string, providerType uint64, fee uint64) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err
 	}
 
 	type stakePoolRequest struct {
-		BlobberID string `json:"blobber_id"`
+		ProviderType uint64 `json:"provider_type,omitempty"`
+		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
-	var spr stakePoolRequest
-	spr.BlobberID = blobberID
+	spr := stakePoolRequest{
+		ProviderType: providerType,
+		ProviderID:   providerId,
+	}
 
 	err = ta.t.createSmartContractTxn(StorageSmartContractAddress,
 		transaction.STORAGESC_STAKE_POOL_UNLOCK, &spr, 0)

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -243,7 +243,7 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType int
 	}
 
 	type stakePoolRequest struct {
-		ProviderType uint64 `json:"provider_type,omitempty"`
+		ProviderType int    `json:"provider_type,omitempty"`
 		ProviderID   string `json:"provider_id,omitempty"`
 	}
 
@@ -270,7 +270,7 @@ func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType i
 	}
 
 	type stakePoolRequest struct {
-		ProviderType uint64 `json:"provider_type,omitempty"`
+		ProviderType int    `json:"provider_type,omitempty"`
 		ProviderID   string `json:"provider_id,omitempty"`
 	}
 

--- a/zcncore/transactionauth_mobile.go
+++ b/zcncore/transactionauth_mobile.go
@@ -230,7 +230,8 @@ func (ta *TransactionWithAuth) ReadPoolUnlock(fee string) error {
 }
 
 // StakePoolLock used to lock tokens in a stake pool of a blobber.
-func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Provider, lock uint64, fee uint64) error {
+func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Provider,
+	lock, fee string) error {
 	lv, err := parseCoinStr(lock)
 	if err != nil {
 		return err
@@ -262,7 +263,7 @@ func (ta *TransactionWithAuth) StakePoolLock(providerId string, providerType Pro
 }
 
 // StakePoolUnlock by blobberID
-func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType Provider, fee uint64) error {
+func (ta *TransactionWithAuth) StakePoolUnlock(providerId string, providerType Provider, fee string) error {
 	v, err := parseCoinStr(fee)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Changes
StakePoolLock and Unlock takes providerId and providerType instead of blobberID 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
