### PR TITLE
wait some time before retrying downloading a file

### DIFF
--- a/zboxcore/sdk/blockdownloadworker.go
+++ b/zboxcore/sdk/blockdownloadworker.go
@@ -204,6 +204,7 @@ func (req *BlockDownloadRequest) downloadBlobberBlock() {
 				if bytes.Contains(respBody, []byte(LockExists)) {
 					zlogger.Logger.Debug("Lock exists error.")
 					shouldRetry = true
+					time.Sleep(time.Second * 1)
 					return errors.New(LockExists, string(respBody))
 				}
 


### PR DESCRIPTION
Repairing fails because there are multiple quick concurrent requests while the resource is locked.

This fix waits 1 second before retrying again.