### PR TITLE
sync fix: check against remote map

### DIFF
--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -180,7 +180,7 @@ func findDelta(rMap map[string]fileInfo, lMap map[string]fileInfo, prevMap map[s
 	// Create a local hash map and find modification
 	lMod := make(map[string]fileInfo)
 	for lFile, lInfo := range lMap {
-		if pm, ok := prevMap[lFile]; ok {
+		if pm, ok := rMap[lFile]; ok {
 			// Local file existed in previous sync also
 			if pm.Hash != lInfo.Hash {
 				// File modified in local


### PR DESCRIPTION
### Changes

To find the changes, we are checking against the difference between hashes of `prevMap`. We should check against `rMap`

lets say we have these 2 maps

```
Remote List: map[/test.txt:{24 12 ed1976943b0728b2fff53c57298a829a71390367c66ef6b9a8987f88256ccc3f f} /test2.txt:{26 13 ee06702b3723f41edb691740634f0e8d5bf6c8830e7938720dfa60ca3838d207 f}]

Local List: map[/.:{0 0  d} /test.txt:{12 0 ed1976943b0728b2fff53c57298a829a71390367c66ef6b9a8987f88256ccc3f f} /test2.txt:{13 0 ee06702b3723f41edb691740634f0e8d5bf6c8830e7938720dfa60ca3838d207 f}]
```

when checking for hashes, we should check for remote hash, so that we can decide whether to upload or not


NOTE:
with this changes, if there is a difference, always the remote file will be overwritten. 

### Fixes
- https://github.com/0chain/zboxcli/issues/139
- https://github.com/0chain/zboxcli/issues/250

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
