### PR TITLE
feat: add offline wallet creation in zcncore

### DIFF
--- a/zcncore/wallet_base.go
+++ b/zcncore/wallet_base.go
@@ -335,6 +335,20 @@ func CreateWallet(statusCb WalletCallback) error {
 	return nil
 }
 
+// CreateWalletOffline creates the wallet for the config signature scheme.
+func CreateWalletOffline() (string, error) {
+	sigScheme := zcncrypto.NewSignatureScheme(_config.chain.SignatureScheme)
+	wallet, err := sigScheme.GenerateKeys()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate keys")
+	}
+	w, err := wallet.Marshal()
+	if err != nil {
+		return "", errors.Wrap(err, "wallet encoding failed")
+	}
+	return w, nil
+}
+
 // registerToMiners can be used to register the wallet.
 func registerToMiners(wallet *zcncrypto.Wallet, statusCb WalletCallback) error {
 	result := make(chan *util.PostResponse)


### PR DESCRIPTION
### Changes
-

Feature required for `create-wallet` cmd in zwalletcli

The existing zcncore `CreateWallet` function registers the wallet to miners (which we don't need in some cases)
https://github.com/0chain/gosdk/blob/a4fee7ae103e201c158523deeb09a68a1b45976f/zcncore/wallet_base.go#L316-L336

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli: https://github.com/0chain/zwalletcli/pull/190
- Other: ...
