### PR TITLE
feat(wasm): exposed createReadPool

### DIFF
--- a/wasmsdk/README.md
+++ b/wasmsdk/README.md
@@ -161,6 +161,16 @@ convert blobber urls to blobber ids
 > []string
 
 
+### zcn.sdk.createReadPool
+create readpool in storage SC if the pool is missing.
+
+**Input**:
+> N/A
+
+**Output**:
+> string
+
+
 ## Blobber methods
 ### zcn.sdk.delete
 delete remote file from blobbers

--- a/wasmsdk/proxy.go
+++ b/wasmsdk/proxy.go
@@ -178,6 +178,7 @@ func main() {
 
 				//zcn
 				"getWalletBalance": getWalletBalance,
+				"createReadPool":   createReadPool,
 			})
 
 			fmt.Println("__wasm_initialized__ = true;")

--- a/wasmsdk/zcn.go
+++ b/wasmsdk/zcn.go
@@ -3,7 +3,10 @@
 
 package main
 
-import "github.com/0chain/gosdk/zcncore"
+import (
+	"github.com/0chain/gosdk/zboxcore/sdk"
+	"github.com/0chain/gosdk/zcncore"
+)
 
 type Balance struct {
 	ZCN float64 `json:"zcn"`
@@ -26,4 +29,9 @@ func getWalletBalance(clientId string) (*Balance, error) {
 		ZCN: zcn.ToToken(),
 		USD: usd,
 	}, nil
+}
+
+func createReadPool() (string, error) {
+	hash, _, err := sdk.CreateReadPool()
+	return hash, err
 }

--- a/zboxcore/client/entity.go
+++ b/zboxcore/client/entity.go
@@ -112,7 +112,7 @@ func SignHash(hash string, signatureScheme string, keys []sys.KeyPair) (string, 
 
 func VerifySignature(signature string, msg string) (bool, error) {
 	ss := zcncrypto.NewSignatureScheme(client.SignatureScheme)
-	if err := ss.SetPublicKey(client.Keys[0].PublicKey); err != nil {
+	if err := ss.SetPublicKey(client.ClientKey); err != nil {
 		return false, err
 	}
 

--- a/zboxcore/marker/writemarker.go
+++ b/zboxcore/marker/writemarker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/0chain/errors"
 	"github.com/0chain/gosdk/core/encryption"
+	"github.com/0chain/gosdk/core/sys"
 	"github.com/0chain/gosdk/zboxcore/client"
 )
 
@@ -43,7 +44,7 @@ func (wm *WriteMarker) Sign() error {
 func (wm *WriteMarker) VerifySignature(clientPublicKey string) error {
 	hashData := wm.GetHashData()
 	signatureHash := encryption.Hash(hashData)
-	sigOK, err := client.VerifySignature(wm.Signature, signatureHash)
+	sigOK, err := sys.Verify(wm.Signature, signatureHash)
 	if err != nil {
 		return errors.New("write_marker_validation_failed", "Error during verifying signature. "+err.Error())
 	}


### PR DESCRIPTION
### Changes
- added `sdk.createReadPool`

### Fixes
- fixed panicking issue on signature verify of WriteMarker in wasm sdk.

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
