### PR TITLE
Fix: remove "client_id" field from zcnbridge critical

### DIFF
--- a/zcnbridge/ethereum/mint_payload.go
+++ b/zcnbridge/ethereum/mint_payload.go
@@ -4,11 +4,10 @@ import "encoding/json"
 
 // MintPayload Payload to submit to the ethereum bridge contract
 type MintPayload struct {
-	ZCNTxnID        string                 `json:"zcn_txn_id"`
-	EthereumAddress string                 `json:"ethereum_address"`
-	Amount          int64                  `json:"amount"`
-	Nonce           int64                  `json:"nonce"`
-	Signatures      []*AuthorizerSignature `json:"signatures"`
+	ZCNTxnID   string                 `json:"zcn_txn_id"`
+	Amount     int64                  `json:"amount"`
+	Nonce      int64                  `json:"nonce"`
+	Signatures []*AuthorizerSignature `json:"signatures"`
 }
 
 type AuthorizerSignature struct {


### PR DESCRIPTION
Refers to issue #635