### PR TITLE
fix(mobile): added x86_64 support on android sdk

### DIFF
--- a/_util/build_mobile.mk
+++ b/_util/build_mobile.mk
@@ -9,7 +9,7 @@ ANDROIDBINNAME	:= zcncore.aar
 
 PKG_EXPORTS := $(GOSDK_PATH)/zcncore $(GOSDK_PATH)/core/common $(GOSDK_PATH)/mobilesdk/sdk $(GOSDK_PATH)/mobilesdk/zbox
 
-.PHONY: setup-gomobile build-iossimulator build-ios
+.PHONY: setup-gomobile build-iossimulator build-ios build-android build-android-debug
 
 $(IOSMOBILESDKDIR):
 	$(shell mkdir -p $(IOSMOBILESDKDIR)/lib)
@@ -63,7 +63,12 @@ build-ios:
 
 build-android: 
 	@echo "Building Android framework. Please wait..."
-	@gomobile bind -target=android/arm64 -tags mobile -ldflags=-extldflags=-Wl,-soname,libgojni.so -o $(ANDROIDMOBILESDKDIR)/$(ANDROIDBINNAME) $(PKG_EXPORTS)
+	@gomobile bind -v -ldflags="-s -w -extldflags=-Wl,-soname,libgojni.so" -target=android/arm64,android/amd64 -tags mobile  -o $(ANDROIDMOBILESDKDIR)/$(ANDROIDBINNAME) $(PKG_EXPORTS)
+	@echo "   $(ANDROIDMOBILESDKDIR)/$(ANDROIDBINNAME). - [OK]"
+
+build-android-debug: 
+	@echo "Building Android framework. Please wait..."
+	@gomobile bind -v -ldflags="-extldflags=-Wl" -gcflags '-N -l' -target=android/arm64,android/amd64 -tags mobile  -o $(ANDROIDMOBILESDKDIR)/$(ANDROIDBINNAME) $(PKG_EXPORTS)
 	@echo "   $(ANDROIDMOBILESDKDIR)/$(ANDROIDBINNAME). - [OK]"
 
 build-macos: 


### PR DESCRIPTION
### Changes
- added x86_64 support on android sdk

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
