### PR TITLE
Floor end block greater than total shards

### DIFF
--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -522,7 +522,7 @@ func (req *DownloadRequest) calculateShardsParams(
 
 	chunksPerShard = (effectivePerShardSize + effectiveChunkSize - 1) / effectiveChunkSize
 	actualPerShard = chunksPerShard * fRef.ChunkSize
-	if req.endBlock == 0 {
+	if req.endBlock == 0 || req.endBlock > chunksPerShard {
 		req.endBlock = chunksPerShard
 	}
 


### PR DESCRIPTION
### Changes
-

### Fixes
- This PR will fix download's `no shard` issue by flooring end block that is greater than total shards to total shards.

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli: https://github.com/0chain/zboxcli/pull/328
- zwalletcli:
- Other: ...
