### PR TITLE
feat(wasm): exposed cancelAllocation and updateAllocation in wasm

### DIFF
--- a/wasmsdk/README.md
+++ b/wasmsdk/README.md
@@ -130,7 +130,17 @@ list all allocations
 get allocation detail
 
 **Input**:
-> allocationId string, refresh bool
+> allocationID string
+
+**Output**:
+> [sdk.Allocation](https://github.com/0chain/gosdk/blob/a9e504e4a0e8fc76a05679e4ef183bb03b8db8e5/zboxcore/sdk/allocation.go#L140)
+
+
+### zcn.sdk.reloadAllocation
+clean cache, and get allocation detail from blockchain
+
+**Input**:
+> allocationID string
 
 **Output**:
 > [sdk.Allocation](https://github.com/0chain/gosdk/blob/a9e504e4a0e8fc76a05679e4ef183bb03b8db8e5/zboxcore/sdk/allocation.go#L140)

--- a/wasmsdk/README.md
+++ b/wasmsdk/README.md
@@ -142,7 +142,25 @@ freeze allocation so that data can no longer be modified
 > allocationId string
 
 **Output**:
-> N/A
+> hash: string
+
+### zcn.sdk.cancelAllocation
+immediately return all remaining tokens from challenge pool back to the allocation's owner and cancels the allocation. If blobbers already got some tokens, the tokens will not be returned. Remaining min lock payment to the blobber will be funded from the allocation's write pools.
+
+**Input**:
+> allocationId string
+
+**Output**:
+> hash: string
+
+### zcn.sdk.updateAllocation
+updates allocation settings
+
+**Input**:
+> allocationId string, name string,size, expiry int64,lock int64,setImmutable, updateTerms bool,addBlobberId, removeBlobberId string
+
+**Output**:
+> hash: string
 
 
 ### zcn.sdk.getWalletBalance

--- a/wasmsdk/README.md
+++ b/wasmsdk/README.md
@@ -130,7 +130,7 @@ list all allocations
 get allocation detail
 
 **Input**:
-> N/A
+> allocationId string, refresh bool
 
 **Output**:
 > [sdk.Allocation](https://github.com/0chain/gosdk/blob/a9e504e4a0e8fc76a05679e4ef183bb03b8db8e5/zboxcore/sdk/allocation.go#L140)

--- a/wasmsdk/README.md
+++ b/wasmsdk/README.md
@@ -124,6 +124,16 @@ list all allocations
 
 **Output**:
 > [sdk.Allocation](https://github.com/0chain/gosdk/blob/a9e504e4a0e8fc76a05679e4ef183bb03b8db8e5/zboxcore/sdk/allocation.go#L140) array
+>
+
+### zcn.sdk.getAllocation
+get allocation detail
+
+**Input**:
+> N/A
+
+**Output**:
+> [sdk.Allocation](https://github.com/0chain/gosdk/blob/a9e504e4a0e8fc76a05679e4ef183bb03b8db8e5/zboxcore/sdk/allocation.go#L140)
 
 ### zcn.sdk.transferAllocation
 changes the owner of an allocation. Only a curator or the current owner of the allocation, can change an allocation's ownership.

--- a/wasmsdk/allocation.go
+++ b/wasmsdk/allocation.go
@@ -75,6 +75,10 @@ func transferAllocation(allocationID, newOwnerId, newOwnerPublicKey string) erro
 
 	_, _, err := sdk.CuratorTransferAllocation(allocationID, newOwnerId, newOwnerPublicKey)
 
+	if err == nil {
+		clearAllocation(allocationID)
+	}
+
 	return err
 }
 
@@ -92,12 +96,20 @@ func freezeAllocation(allocationID string) (string, error) {
 		"",           //removeBlobberId,
 	)
 
+	if err == nil {
+		clearAllocation(allocationID)
+	}
+
 	return hash, err
 
 }
 
 func cancelAllocation(allocationID string) (string, error) {
 	hash, _, err := sdk.CancelAllocation(allocationID)
+
+	if err == nil {
+		clearAllocation(allocationID)
+	}
 
 	return hash, err
 }
@@ -108,5 +120,10 @@ func updateAllocation(allocationID string, name string,
 	setImmutable, updateTerms bool,
 	addBlobberId, removeBlobberId string) (string, error) {
 	hash, _, err := sdk.UpdateAllocation(name, size, expiry, allocationID, uint64(lock), setImmutable, updateTerms, addBlobberId, removeBlobberId)
+
+	if err == nil {
+		clearAllocation(allocationID)
+	}
+
 	return hash, err
 }

--- a/wasmsdk/allocation.go
+++ b/wasmsdk/allocation.go
@@ -78,9 +78,9 @@ func transferAllocation(allocationId, newOwnerId, newOwnerPublicKey string) erro
 	return err
 }
 
-func freezeAllocation(allocationId string) error {
+func freezeAllocation(allocationId string) (string, error) {
 
-	_, _, err := sdk.UpdateAllocation(
+	hash, _, err := sdk.UpdateAllocation(
 		"",           //allocationName,
 		0,            //size,
 		0,            //int64(expiry/time.Second),
@@ -92,6 +92,21 @@ func freezeAllocation(allocationId string) error {
 		"",           //removeBlobberId,
 	)
 
-	return err
+	return hash, err
 
+}
+
+func cancelAllocation(allocationId string) (string, error) {
+	hash, _, err := sdk.CancelAllocation(allocationId)
+
+	return hash, err
+}
+
+func updateAllocation(allocationId string, name string,
+	size, expiry int64,
+	lock int64,
+	setImmutable, updateTerms bool,
+	addBlobberId, removeBlobberId string) (string, error) {
+	hash, _, err := sdk.UpdateAllocation(name, size, expiry, allocationId, uint64(lock), setImmutable, updateTerms, addBlobberId, removeBlobberId)
+	return hash, err
 }

--- a/wasmsdk/allocation.go
+++ b/wasmsdk/allocation.go
@@ -60,9 +60,9 @@ func listAllocations() ([]*sdk.Allocation, error) {
 	return sdk.GetAllocations()
 }
 
-func transferAllocation(allocationId, newOwnerId, newOwnerPublicKey string) error {
-	if allocationId == "" {
-		return RequiredArg("allocationId")
+func transferAllocation(allocationID, newOwnerId, newOwnerPublicKey string) error {
+	if allocationID == "" {
+		return RequiredArg("allocationID")
 	}
 
 	if newOwnerId == "" {
@@ -73,18 +73,18 @@ func transferAllocation(allocationId, newOwnerId, newOwnerPublicKey string) erro
 		return RequiredArg("newOwnerPublicKey")
 	}
 
-	_, _, err := sdk.CuratorTransferAllocation(allocationId, newOwnerId, newOwnerPublicKey)
+	_, _, err := sdk.CuratorTransferAllocation(allocationID, newOwnerId, newOwnerPublicKey)
 
 	return err
 }
 
-func freezeAllocation(allocationId string) (string, error) {
+func freezeAllocation(allocationID string) (string, error) {
 
 	hash, _, err := sdk.UpdateAllocation(
 		"",           //allocationName,
 		0,            //size,
 		0,            //int64(expiry/time.Second),
-		allocationId, // allocID,
+		allocationID, // allocID,
 		0,            //lock,
 		true,         // setImmutable,
 		false,        //updateTerms,
@@ -96,17 +96,17 @@ func freezeAllocation(allocationId string) (string, error) {
 
 }
 
-func cancelAllocation(allocationId string) (string, error) {
-	hash, _, err := sdk.CancelAllocation(allocationId)
+func cancelAllocation(allocationID string) (string, error) {
+	hash, _, err := sdk.CancelAllocation(allocationID)
 
 	return hash, err
 }
 
-func updateAllocation(allocationId string, name string,
+func updateAllocation(allocationID string, name string,
 	size, expiry int64,
 	lock int64,
 	setImmutable, updateTerms bool,
 	addBlobberId, removeBlobberId string) (string, error) {
-	hash, _, err := sdk.UpdateAllocation(name, size, expiry, allocationId, uint64(lock), setImmutable, updateTerms, addBlobberId, removeBlobberId)
+	hash, _, err := sdk.UpdateAllocation(name, size, expiry, allocationID, uint64(lock), setImmutable, updateTerms, addBlobberId, removeBlobberId)
 	return hash, err
 }

--- a/wasmsdk/blobber.go
+++ b/wasmsdk/blobber.go
@@ -23,7 +23,7 @@ import (
 )
 
 func listObjects(allocationId string, remotePath string) (*sdk.ListResult, error) {
-	alloc, err := getAllocation(allocationId)
+	alloc, err := getAllocation(allocationId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -32,16 +32,16 @@ func listObjects(allocationId string, remotePath string) (*sdk.ListResult, error
 
 }
 
-func createDir(allocationID, remotePath string) error {
-	if len(allocationID) == 0 {
-		return RequiredArg("allocationID")
+func createDir(allocationId, remotePath string) error {
+	if len(allocationId) == 0 {
+		return RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
 		return RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		return err
 	}
@@ -50,16 +50,16 @@ func createDir(allocationID, remotePath string) error {
 }
 
 // getFileStats get file stats from blobbers
-func getFileStats(allocationID, remotePath string) ([]*sdk.FileStats, error) {
-	if len(allocationID) == 0 {
-		return nil, RequiredArg("allocationID")
+func getFileStats(allocationId, remotePath string) ([]*sdk.FileStats, error) {
+	if len(allocationId) == 0 {
+		return nil, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
 		return nil, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -79,17 +79,17 @@ func getFileStats(allocationID, remotePath string) ([]*sdk.FileStats, error) {
 }
 
 // Delete delete file from blobbers
-func Delete(allocationID, remotePath string) (*FileCommandResponse, error) {
+func Delete(allocationId, remotePath string) (*FileCommandResponse, error) {
 
-	if len(allocationID) == 0 {
-		return nil, RequiredArg("allocationID")
+	if len(allocationId) == 0 {
+		return nil, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
 		return nil, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -109,9 +109,9 @@ func Delete(allocationID, remotePath string) (*FileCommandResponse, error) {
 }
 
 // Rename rename a file existing already on dStorage. Only the allocation's owner can rename a file.
-func Rename(allocationID, remotePath, destName string) (*FileCommandResponse, error) {
-	if len(allocationID) == 0 {
-		return nil, RequiredArg("allocationID")
+func Rename(allocationId, remotePath, destName string) (*FileCommandResponse, error) {
+	if len(allocationId) == 0 {
+		return nil, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
@@ -122,7 +122,7 @@ func Rename(allocationID, remotePath, destName string) (*FileCommandResponse, er
 		return nil, RequiredArg("destName")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -143,10 +143,10 @@ func Rename(allocationID, remotePath, destName string) (*FileCommandResponse, er
 }
 
 // Copy copy file to another folder path on blobbers
-func Copy(allocationID, remotePath, destPath string) (*FileCommandResponse, error) {
+func Copy(allocationId, remotePath, destPath string) (*FileCommandResponse, error) {
 
-	if len(allocationID) == 0 {
-		return nil, RequiredArg("allocationID")
+	if len(allocationId) == 0 {
+		return nil, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
@@ -157,7 +157,7 @@ func Copy(allocationID, remotePath, destPath string) (*FileCommandResponse, erro
 		return nil, RequiredArg("destPath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -179,9 +179,9 @@ func Copy(allocationID, remotePath, destPath string) (*FileCommandResponse, erro
 }
 
 // Move move file to another remote folder path on dStorage. Only the owner of the allocation can copy an object.
-func Move(allocationID, remotePath, destPath string) (*FileCommandResponse, error) {
-	if len(allocationID) == 0 {
-		return nil, RequiredArg("allocationID")
+func Move(allocationId, remotePath, destPath string) (*FileCommandResponse, error) {
+	if len(allocationId) == 0 {
+		return nil, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
@@ -192,7 +192,7 @@ func Move(allocationID, remotePath, destPath string) (*FileCommandResponse, erro
 		return nil, RequiredArg("destPath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -214,17 +214,17 @@ func Move(allocationID, remotePath, destPath string) (*FileCommandResponse, erro
 }
 
 // Share  generate an authtoken that provides authorization to the holder to the specified file on the remotepath.
-func Share(allocationID, remotePath, clientID, encryptionPublicKey string, expiration int, revoke bool, availableAfter string) (string, error) {
+func Share(allocationId, remotePath, clientID, encryptionPublicKey string, expiration int, revoke bool, availableAfter string) (string, error) {
 
-	if len(allocationID) == 0 {
-		return "", RequiredArg("allocationID")
+	if len(allocationId) == 0 {
+		return "", RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
 		return "", RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return "", err
@@ -284,7 +284,7 @@ func Share(allocationID, remotePath, clientID, encryptionPublicKey string, expir
 }
 
 // download download file
-func download(allocationID, remotePath, authTicket, lookupHash string, downloadThumbnailOnly bool, numBlocks int) (*DownloadCommandResponse, error) {
+func download(allocationId, remotePath, authTicket, lookupHash string, downloadThumbnailOnly bool, numBlocks int) (*DownloadCommandResponse, error) {
 
 	if len(remotePath) == 0 && len(authTicket) == 0 {
 		return nil, RequiredArg("remotePath/authTicket")
@@ -295,9 +295,9 @@ func download(allocationID, remotePath, authTicket, lookupHash string, downloadT
 	wg.Add(1)
 
 	fileName := strings.Replace(path.Base(remotePath), "/", "-", -1)
-	localPath := allocationID + "_" + fileName
+	localPath := allocationId + "_" + fileName
 
-	downloader, err := sdk.CreateDownloader(allocationID, localPath, remotePath,
+	downloader, err := sdk.CreateDownloader(allocationId, localPath, remotePath,
 		sdk.WithAuthticket(authTicket, lookupHash),
 		sdk.WithOnlyThumbnail(downloadThumbnailOnly),
 		sdk.WithBlocks(0, 0, numBlocks))
@@ -337,7 +337,7 @@ func download(allocationID, remotePath, authTicket, lookupHash string, downloadT
 }
 
 type BulkUploadOption struct {
-	AllocationID string `json:"allocationID,omitempty"`
+	allocationId string `json:"allocationId,omitempty"`
 	RemotePath   string `json:"remotePath,omitempty"`
 
 	ThumbnailBytes []byte `json:"thumbnailBytes,omitempty"`
@@ -374,7 +374,7 @@ func bulkUpload(jsonBulkUploadOptions string) ([]BulkUploadResult, error) {
 			}
 			defer func() { wait <- result }()
 
-			ok, err := uploadWithJsFuncs(o.AllocationID, o.RemotePath,
+			ok, err := uploadWithJsFuncs(o.allocationId, o.RemotePath,
 				o.ReadChunkFuncName,
 				o.FileSize,
 				o.ThumbnailBytes,
@@ -402,17 +402,17 @@ func bulkUpload(jsonBulkUploadOptions string) ([]BulkUploadResult, error) {
 	return results, nil
 }
 
-func uploadWithJsFuncs(allocationID, remotePath string, readChunkFuncName string, fileSize int64, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int, callbackFuncName string) (bool, error) {
+func uploadWithJsFuncs(allocationId, remotePath string, readChunkFuncName string, fileSize int64, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int, callbackFuncName string) (bool, error) {
 
-	if len(allocationID) == 0 {
-		return false, RequiredArg("allocationID")
+	if len(allocationId) == 0 {
+		return false, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
 		return false, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return false, err
@@ -488,16 +488,16 @@ func uploadWithJsFuncs(allocationID, remotePath string, readChunkFuncName string
 }
 
 // upload upload file
-func upload(allocationID, remotePath string, fileBytes, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int) (*FileCommandResponse, error) {
-	if len(allocationID) == 0 {
-		return nil, RequiredArg("allocationID")
+func upload(allocationId, remotePath string, fileBytes, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int) (*FileCommandResponse, error) {
+	if len(allocationId) == 0 {
+		return nil, RequiredArg("allocationId")
 	}
 
 	if len(remotePath) == 0 {
 		return nil, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationID)
+	allocationObj, err := getAllocation(allocationId, false)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -570,7 +570,7 @@ func upload(allocationID, remotePath string, fileBytes, thumbnailBytes []byte, e
 }
 
 // download download file blocks
-func downloadBlocks(allocationID, remotePath, authTicket, lookupHash string, numBlocks int, startBlockNumber, endBlockNumber int64) (*DownloadCommandResponse, error) {
+func downloadBlocks(allocationId, remotePath, authTicket, lookupHash string, numBlocks int, startBlockNumber, endBlockNumber int64) (*DownloadCommandResponse, error) {
 
 	if len(remotePath) == 0 && len(authTicket) == 0 {
 		return nil, RequiredArg("remotePath/authTicket")
@@ -581,9 +581,9 @@ func downloadBlocks(allocationID, remotePath, authTicket, lookupHash string, num
 	wg.Add(1)
 
 	fileName := strings.Replace(path.Base(remotePath), "/", "-", -1)
-	localPath := filepath.Join(allocationID, fileName)
+	localPath := filepath.Join(allocationId, fileName)
 
-	downloader, err := sdk.CreateDownloader(allocationID, localPath, remotePath,
+	downloader, err := sdk.CreateDownloader(allocationId, localPath, remotePath,
 		sdk.WithAuthticket(authTicket, lookupHash),
 		sdk.WithBlocks(startBlockNumber, endBlockNumber, numBlocks))
 

--- a/wasmsdk/blobber.go
+++ b/wasmsdk/blobber.go
@@ -22,8 +22,8 @@ import (
 	"github.com/0chain/gosdk/zboxcore/zboxutil"
 )
 
-func listObjects(allocationId string, remotePath string) (*sdk.ListResult, error) {
-	alloc, err := getAllocation(allocationId, false)
+func listObjects(allocationID string, remotePath string) (*sdk.ListResult, error) {
+	alloc, err := getAllocation(allocationID)
 	if err != nil {
 		return nil, err
 	}
@@ -32,16 +32,16 @@ func listObjects(allocationId string, remotePath string) (*sdk.ListResult, error
 
 }
 
-func createDir(allocationId, remotePath string) error {
-	if len(allocationId) == 0 {
-		return RequiredArg("allocationId")
+func createDir(allocationID, remotePath string) error {
+	if len(allocationID) == 0 {
+		return RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
 		return RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		return err
 	}
@@ -50,16 +50,16 @@ func createDir(allocationId, remotePath string) error {
 }
 
 // getFileStats get file stats from blobbers
-func getFileStats(allocationId, remotePath string) ([]*sdk.FileStats, error) {
-	if len(allocationId) == 0 {
-		return nil, RequiredArg("allocationId")
+func getFileStats(allocationID, remotePath string) ([]*sdk.FileStats, error) {
+	if len(allocationID) == 0 {
+		return nil, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
 		return nil, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		return nil, err
 	}
@@ -79,17 +79,17 @@ func getFileStats(allocationId, remotePath string) ([]*sdk.FileStats, error) {
 }
 
 // Delete delete file from blobbers
-func Delete(allocationId, remotePath string) (*FileCommandResponse, error) {
+func Delete(allocationID, remotePath string) (*FileCommandResponse, error) {
 
-	if len(allocationId) == 0 {
-		return nil, RequiredArg("allocationId")
+	if len(allocationID) == 0 {
+		return nil, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
 		return nil, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		return nil, err
 	}
@@ -109,9 +109,9 @@ func Delete(allocationId, remotePath string) (*FileCommandResponse, error) {
 }
 
 // Rename rename a file existing already on dStorage. Only the allocation's owner can rename a file.
-func Rename(allocationId, remotePath, destName string) (*FileCommandResponse, error) {
-	if len(allocationId) == 0 {
-		return nil, RequiredArg("allocationId")
+func Rename(allocationID, remotePath, destName string) (*FileCommandResponse, error) {
+	if len(allocationID) == 0 {
+		return nil, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
@@ -122,7 +122,7 @@ func Rename(allocationId, remotePath, destName string) (*FileCommandResponse, er
 		return nil, RequiredArg("destName")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -143,10 +143,10 @@ func Rename(allocationId, remotePath, destName string) (*FileCommandResponse, er
 }
 
 // Copy copy file to another folder path on blobbers
-func Copy(allocationId, remotePath, destPath string) (*FileCommandResponse, error) {
+func Copy(allocationID, remotePath, destPath string) (*FileCommandResponse, error) {
 
-	if len(allocationId) == 0 {
-		return nil, RequiredArg("allocationId")
+	if len(allocationID) == 0 {
+		return nil, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
@@ -157,7 +157,7 @@ func Copy(allocationId, remotePath, destPath string) (*FileCommandResponse, erro
 		return nil, RequiredArg("destPath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -179,9 +179,9 @@ func Copy(allocationId, remotePath, destPath string) (*FileCommandResponse, erro
 }
 
 // Move move file to another remote folder path on dStorage. Only the owner of the allocation can copy an object.
-func Move(allocationId, remotePath, destPath string) (*FileCommandResponse, error) {
-	if len(allocationId) == 0 {
-		return nil, RequiredArg("allocationId")
+func Move(allocationID, remotePath, destPath string) (*FileCommandResponse, error) {
+	if len(allocationID) == 0 {
+		return nil, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
@@ -192,7 +192,7 @@ func Move(allocationId, remotePath, destPath string) (*FileCommandResponse, erro
 		return nil, RequiredArg("destPath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -214,17 +214,17 @@ func Move(allocationId, remotePath, destPath string) (*FileCommandResponse, erro
 }
 
 // Share  generate an authtoken that provides authorization to the holder to the specified file on the remotepath.
-func Share(allocationId, remotePath, clientID, encryptionPublicKey string, expiration int, revoke bool, availableAfter string) (string, error) {
+func Share(allocationID, remotePath, clientID, encryptionPublicKey string, expiration int, revoke bool, availableAfter string) (string, error) {
 
-	if len(allocationId) == 0 {
-		return "", RequiredArg("allocationId")
+	if len(allocationID) == 0 {
+		return "", RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
 		return "", RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return "", err
@@ -284,7 +284,7 @@ func Share(allocationId, remotePath, clientID, encryptionPublicKey string, expir
 }
 
 // download download file
-func download(allocationId, remotePath, authTicket, lookupHash string, downloadThumbnailOnly bool, numBlocks int) (*DownloadCommandResponse, error) {
+func download(allocationID, remotePath, authTicket, lookupHash string, downloadThumbnailOnly bool, numBlocks int) (*DownloadCommandResponse, error) {
 
 	if len(remotePath) == 0 && len(authTicket) == 0 {
 		return nil, RequiredArg("remotePath/authTicket")
@@ -295,9 +295,9 @@ func download(allocationId, remotePath, authTicket, lookupHash string, downloadT
 	wg.Add(1)
 
 	fileName := strings.Replace(path.Base(remotePath), "/", "-", -1)
-	localPath := allocationId + "_" + fileName
+	localPath := allocationID + "_" + fileName
 
-	downloader, err := sdk.CreateDownloader(allocationId, localPath, remotePath,
+	downloader, err := sdk.CreateDownloader(allocationID, localPath, remotePath,
 		sdk.WithAuthticket(authTicket, lookupHash),
 		sdk.WithOnlyThumbnail(downloadThumbnailOnly),
 		sdk.WithBlocks(0, 0, numBlocks))
@@ -337,7 +337,7 @@ func download(allocationId, remotePath, authTicket, lookupHash string, downloadT
 }
 
 type BulkUploadOption struct {
-	allocationId string `json:"allocationId,omitempty"`
+	allocationID string `json:"allocationID,omitempty"`
 	RemotePath   string `json:"remotePath,omitempty"`
 
 	ThumbnailBytes []byte `json:"thumbnailBytes,omitempty"`
@@ -374,7 +374,7 @@ func bulkUpload(jsonBulkUploadOptions string) ([]BulkUploadResult, error) {
 			}
 			defer func() { wait <- result }()
 
-			ok, err := uploadWithJsFuncs(o.allocationId, o.RemotePath,
+			ok, err := uploadWithJsFuncs(o.allocationID, o.RemotePath,
 				o.ReadChunkFuncName,
 				o.FileSize,
 				o.ThumbnailBytes,
@@ -402,17 +402,17 @@ func bulkUpload(jsonBulkUploadOptions string) ([]BulkUploadResult, error) {
 	return results, nil
 }
 
-func uploadWithJsFuncs(allocationId, remotePath string, readChunkFuncName string, fileSize int64, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int, callbackFuncName string) (bool, error) {
+func uploadWithJsFuncs(allocationID, remotePath string, readChunkFuncName string, fileSize int64, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int, callbackFuncName string) (bool, error) {
 
-	if len(allocationId) == 0 {
-		return false, RequiredArg("allocationId")
+	if len(allocationID) == 0 {
+		return false, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
 		return false, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return false, err
@@ -488,16 +488,16 @@ func uploadWithJsFuncs(allocationId, remotePath string, readChunkFuncName string
 }
 
 // upload upload file
-func upload(allocationId, remotePath string, fileBytes, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int) (*FileCommandResponse, error) {
-	if len(allocationId) == 0 {
-		return nil, RequiredArg("allocationId")
+func upload(allocationID, remotePath string, fileBytes, thumbnailBytes []byte, encrypt, isUpdate, isRepair bool, numBlocks int) (*FileCommandResponse, error) {
+	if len(allocationID) == 0 {
+		return nil, RequiredArg("allocationID")
 	}
 
 	if len(remotePath) == 0 {
 		return nil, RequiredArg("remotePath")
 	}
 
-	allocationObj, err := getAllocation(allocationId, false)
+	allocationObj, err := getAllocation(allocationID)
 	if err != nil {
 		PrintError("Error fetching the allocation", err)
 		return nil, err
@@ -570,7 +570,7 @@ func upload(allocationId, remotePath string, fileBytes, thumbnailBytes []byte, e
 }
 
 // download download file blocks
-func downloadBlocks(allocationId, remotePath, authTicket, lookupHash string, numBlocks int, startBlockNumber, endBlockNumber int64) (*DownloadCommandResponse, error) {
+func downloadBlocks(allocationID, remotePath, authTicket, lookupHash string, numBlocks int, startBlockNumber, endBlockNumber int64) (*DownloadCommandResponse, error) {
 
 	if len(remotePath) == 0 && len(authTicket) == 0 {
 		return nil, RequiredArg("remotePath/authTicket")
@@ -581,9 +581,9 @@ func downloadBlocks(allocationId, remotePath, authTicket, lookupHash string, num
 	wg.Add(1)
 
 	fileName := strings.Replace(path.Base(remotePath), "/", "-", -1)
-	localPath := filepath.Join(allocationId, fileName)
+	localPath := filepath.Join(allocationID, fileName)
 
-	downloader, err := sdk.CreateDownloader(allocationId, localPath, remotePath,
+	downloader, err := sdk.CreateDownloader(allocationID, localPath, remotePath,
 		sdk.WithAuthticket(authTicket, lookupHash),
 		sdk.WithBlocks(startBlockNumber, endBlockNumber, numBlocks))
 

--- a/wasmsdk/cache.go
+++ b/wasmsdk/cache.go
@@ -47,6 +47,11 @@ func getAllocation(allocationId string) (*sdk.Allocation, error) {
 	return it.Allocation, nil
 }
 
+// clearAllocation remove allocation from caching
+func clearAllocation(allocationID string) {
+	cachedAllocations.Remove(allocationID)
+}
+
 func reloadAllocation(allocationID string) (*sdk.Allocation, error) {
 	a, err := sdk.GetAllocation(allocationID)
 	if err != nil {

--- a/wasmsdk/proxy.go
+++ b/wasmsdk/proxy.go
@@ -168,6 +168,7 @@ func main() {
 				"getBlobberIds":         getBlobberIds,
 				"listAllocations":       listAllocations,
 				"getAllocation":         getAllocation,
+				"reloadAllocation":      reloadAllocation,
 				"transferAllocation":    transferAllocation,
 				"freezeAllocation":      freezeAllocation,
 				"cancelAllocation":      cancelAllocation,

--- a/wasmsdk/proxy.go
+++ b/wasmsdk/proxy.go
@@ -167,6 +167,7 @@ func main() {
 				"getAllocationBlobbers": getAllocationBlobbers,
 				"getBlobberIds":         getBlobberIds,
 				"listAllocations":       listAllocations,
+				"getAllocation":         getAllocation,
 				"transferAllocation":    transferAllocation,
 				"freezeAllocation":      freezeAllocation,
 				"cancelAllocation":      cancelAllocation,

--- a/wasmsdk/proxy.go
+++ b/wasmsdk/proxy.go
@@ -169,6 +169,8 @@ func main() {
 				"listAllocations":       listAllocations,
 				"transferAllocation":    transferAllocation,
 				"freezeAllocation":      freezeAllocation,
+				"cancelAllocation":      cancelAllocation,
+				"updateAllocation":      updateAllocation,
 
 				//smartcontract
 				"executeSmartContract": executeSmartContract,


### PR DESCRIPTION
### Changes
- exposed `getAllocation`, `reloadAllocation`, `cancelAllocation` and `updateAllocation` in wasm

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
