### PR TITLE
Fix performance issue in getting a random slice of size n from an input slice

### DIFF
--- a/core/util/rand.go
+++ b/core/util/rand.go
@@ -34,15 +34,6 @@ func MaxInt64(x, y int64) int64 {
 	return y
 }
 
-func checkExists(c string, sl []string) bool {
-	for _, s := range sl {
-		if s == c {
-			return true
-		}
-	}
-	return false
-}
-
 func Shuffle(in []string) (shuffle []string) {
 	shuffle = make([]string, len(in))
 	copy(shuffle, in)
@@ -53,20 +44,17 @@ func Shuffle(in []string) (shuffle []string) {
 	return
 }
 
-//GetRandom returns n random slice from in
+// GetRandom returns n random slice from in
+// If n > len(in), then this will return a shuffled version of in
 func GetRandom(in []string, n int) []string {
+	n = MinInt(len(in), n)
+	n = MaxInt(1, n)
 	out := make([]string, 0)
-	nOut := MinInt(len(in), n)
-	nOut = MaxInt(1, nOut)
-	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for {
-		i := randGen.Intn(len(in))
-		if !checkExists(in[i], out) {
-			out = append(out, in[i])
-		}
-		if len(out) >= nOut {
-			break
-		}
+
+	rand.Seed(time.Now().UnixNano())
+	perm := rand.Perm(len(in))
+	for i := 0; i < n; i++ {
+		out = append(out, in[perm[i]])
 	}
 	return out
 }

--- a/core/util/rand.go
+++ b/core/util/rand.go
@@ -48,7 +48,6 @@ func Shuffle(in []string) (shuffle []string) {
 // If n > len(in), then this will return a shuffled version of in
 func GetRandom(in []string, n int) []string {
 	n = MinInt(len(in), n)
-	n = MaxInt(1, n)
 	out := make([]string, 0)
 
 	rand.Seed(time.Now().UnixNano())

--- a/core/util/rand_test.go
+++ b/core/util/rand_test.go
@@ -16,6 +16,17 @@ func TestGetRandomSlice(t *testing.T) {
 	if len(ns) != 3 {
 		t.Fatalf("Getrandom() failed")
 	}
+	// Tests for when either len(in) = 0 or n = 0
+	s = []string{}
+	ns = GetRandom(s, 2)
+	if len(ns) != 0 {
+		t.Fatalf("Getrandom() failed")
+	}
+	s = append(s, "hello")
+	ns = GetRandom(s, 0)
+	if len(ns) != 0 {
+		t.Fatalf("Getrandom() failed")
+	}
 }
 
 func TestRand(t *testing.T) {


### PR DESCRIPTION
### Changes
Improves the performance of generating a random slice of size 'n' from an input slice, from O(n^2) to O(n). This will significantly improve performance when there are lots of miners/sharders in the network.

### Fixes
Fixes #748 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [x]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [x]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
