### PR TITLE
Remove sending custom timeout as an option to resty object

### DIFF
--- a/core/resty/option.go
+++ b/core/resty/option.go
@@ -2,7 +2,6 @@ package resty
 
 import (
 	"net/http"
-	"time"
 )
 
 // WithRetry set retry times if request is failure with 5xx status code. retry is ingore if it is less than 1.
@@ -23,15 +22,6 @@ func WithHeader(header map[string]string) Option {
 
 		for k, v := range header {
 			r.header[k] = v
-		}
-	}
-}
-
-// WithTimeout set timeout of http request.
-func WithTimeout(timeout time.Duration) Option {
-	return func(r *Resty) {
-		if timeout > 0 {
-			r.timeout = timeout
 		}
 	}
 }

--- a/core/resty/resty.go
+++ b/core/resty/resty.go
@@ -16,6 +16,8 @@ import (
 // New create a Resty instance.
 func New(opts ...Option) *Resty {
 	r := &Resty{
+		// Default timeout to use for HTTP requests when either the parent context doesn't have a timeout set
+		// or the context's timeout is longer than DefaultRequestTimeout.
 		timeout: DefaultRequestTimeout,
 		retry:   DefaultRetry,
 		header:  make(map[string]string),

--- a/core/transaction/utils.go
+++ b/core/transaction/utils.go
@@ -35,7 +35,6 @@ func NewOptimisticVerifier(sharders []string) *OptimisticVerifier {
 	transport := createTransport(resty.DefaultDialTimeout)
 
 	options := []resty.Option{
-		resty.WithTimeout(resty.DefaultRequestTimeout),
 		resty.WithRetry(resty.DefaultRetry),
 		resty.WithHeader(header),
 		resty.WithTransport(transport),
@@ -346,7 +345,6 @@ func VerifyTransactionTrusted(txnHash string, sharders []string) (*Transaction, 
 	transport := createTransport(resty.DefaultDialTimeout)
 
 	options := []resty.Option{
-		resty.WithTimeout(resty.DefaultRequestTimeout),
 		resty.WithRetry(resty.DefaultRetry),
 		resty.WithHeader(header),
 		resty.WithTransport(transport),

--- a/sdks/zbox.go
+++ b/sdks/zbox.go
@@ -114,7 +114,6 @@ func (z *ZBox) DoPost(req *Request, handle resty.Handle) *resty.Resty {
 	opts := make([]resty.Option, 0, 5)
 
 	opts = append(opts, resty.WithRetry(resty.DefaultRetry))
-	opts = append(opts, resty.WithTimeout(resty.DefaultRequestTimeout))
 	opts = append(opts, resty.WithRequestInterceptor(func(r *http.Request) error {
 		return z.SignRequest(r, req.AllocationID) //nolint
 	}))

--- a/zboxcore/sdk/playlist.go
+++ b/zboxcore/sdk/playlist.go
@@ -63,7 +63,6 @@ func getPlaylistFromBlobbers(ctx context.Context, alloc *Allocation, query strin
 	opts := make([]resty.Option, 0, 3)
 
 	opts = append(opts, resty.WithRetry(resty.DefaultRetry))
-	opts = append(opts, resty.WithTimeout(resty.DefaultRequestTimeout))
 	opts = append(opts, resty.WithRequestInterceptor(func(req *http.Request) error {
 		req.Header.Set("X-App-Client-ID", client.GetClientID())
 		req.Header.Set("X-App-Client-Key", client.GetClientPublicKey())
@@ -145,7 +144,6 @@ func getPlaylistFileFromBlobbers(ctx context.Context, alloc *Allocation, query s
 	opts := make([]resty.Option, 0, 3)
 
 	opts = append(opts, resty.WithRetry(resty.DefaultRetry))
-	opts = append(opts, resty.WithTimeout(resty.DefaultRequestTimeout))
 	opts = append(opts, resty.WithRequestInterceptor(func(req *http.Request) error {
 		req.Header.Set("X-App-Client-ID", client.GetClientID())
 		req.Header.Set("X-App-Client-Key", client.GetClientPublicKey())

--- a/zcncore/transaction_query_base.go
+++ b/zcncore/transaction_query_base.go
@@ -119,7 +119,12 @@ func (tq *TransactionQuery) checkHealth(ctx context.Context, host string) error 
 	}
 
 	// check health
-	r := resty.New(resty.WithTimeout(5 * time.Second))
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+	r := resty.New()
 	requestUrl := tq.buildUrl(host, SharderEndpointHealthCheck)
 	logging.Info("zcn: check health ", requestUrl)
 	r.DoGet(ctx, requestUrl)
@@ -250,7 +255,12 @@ func (tq *TransactionQuery) FromAll(ctx context.Context, query string, handle Qu
 		urls = append(urls, tq.buildUrl(host, query))
 	}
 
-	r := resty.New(resty.WithTimeout(10 * time.Second))
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+	r := resty.New()
 	r.DoGet(ctx, urls...).
 		Then(func(req *http.Request, resp *http.Response, respBody []byte, cf context.CancelFunc, err error) error {
 			res := QueryResult{


### PR DESCRIPTION
### Changes
- This PR removes the custom timeout param that was being sent while creating resty object. The timeout will now be controlled by the API caller/client through the request context. However, a default timeout of 10s (`DefaultRequestTimeout`) is still there for requests which do not have any timeout set.

### Fixes
- Fixes #737 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
