### PR TITLE
Improve resty package

### DIFF
--- a/core/resty/option.go
+++ b/core/resty/option.go
@@ -2,7 +2,6 @@ package resty
 
 import (
 	"net/http"
-	"time"
 )
 
 // WithRetry set retry times if request is failure with 5xx status code. retry is ingore if it is less than 1.
@@ -23,15 +22,6 @@ func WithHeader(header map[string]string) Option {
 
 		for k, v := range header {
 			r.header[k] = v
-		}
-	}
-}
-
-// WithTimeout set timeout of http request.
-func WithTimeout(timeout time.Duration) Option {
-	return func(r *Resty) {
-		if timeout > 0 {
-			r.timeout = timeout
 		}
 	}
 }

--- a/core/resty/resty.go
+++ b/core/resty/resty.go
@@ -16,6 +16,8 @@ import (
 // New create a Resty instance.
 func New(opts ...Option) *Resty {
 	r := &Resty{
+		// Default timeout to use for HTTP requests when either the parent context doesn't have a timeout set
+		// or the context's timeout is longer than DefaultRequestTimeout.
 		timeout: DefaultRequestTimeout,
 		retry:   DefaultRetry,
 		header:  make(map[string]string),

--- a/core/resty/resty.go
+++ b/core/resty/resty.go
@@ -225,11 +225,14 @@ func (r *Resty) Wait() []error {
 				err := r.handle(result.Request, result.Response, result.ResponseBody, r.cancelFunc, result.Err)
 				if err != nil {
 					errs = append(errs, err)
+				} else if result.Err != nil {
+					// if r.handle doesn't return any error, then append result.Err if it is not nil
+					errs = append(errs, result.Err)
 				}
-			}
-			// needs to be done anyhow to catch cases where r.handle == nil and result.Err != nil.
-			if result.Err != nil {
-				errs = append(errs, result.Err)
+			} else {
+				if result.Err != nil {
+					errs = append(errs, result.Err)
+				}
 			}
 		}
 		done++

--- a/core/resty/resty_test.go
+++ b/core/resty/resty_test.go
@@ -2,6 +2,7 @@ package resty
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -20,96 +21,120 @@ func TestResty(t *testing.T) {
 		urls []string
 
 		statusCode  int
-		exceptedErr error
-
-		setup func(a *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty)
+		expectedErr error
+		setup       func(a *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty)
 	}{
 		{
 			name:        "Test_Resty_Cancel_With_Timeout",
-			exceptedErr: context.DeadlineExceeded,
+			expectedErr: context.DeadlineExceeded,
 			urls:        []string{"Test_Resty_Timeout_1", "Test_Resty_Timeout_2", "Test_Resty_Timeout_3"},
-			setup: func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
-
-				r := New()
-				r.client = &mocks.Timeout{
-					Timeout: 1 * time.Second,
-				}
-
-				ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
-				go func() {
-					<-ctx.Done()
-					cancel()
-				}()
-
-				return ctx, r
-			},
+			setup:       getSetupFuncForCtxDeadlineExtendedTest(),
 		},
 		{
 			name:        "Test_Resty_All_Success",
 			statusCode:  200,
-			exceptedErr: nil,
+			expectedErr: nil,
 			urls:        []string{"http://Test_Resty_Success_1", "http://Test_Resty_Success_2"},
-			setup: func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
-
-				resty := New().Then(func(req *http.Request, resp *http.Response, respBody []byte, cf context.CancelFunc, err error) error {
-
-					ra.Equal(200, resp.StatusCode)
-
-					ra.Equal(nil, err)
-					ra.Equal(name, string(respBody))
-
-					return nil
-				})
-
-				client := &mocks.Client{}
-
-				for _, url := range urls {
-
-					func(u string) {
-						client.On("Do", mock.MatchedBy(func(r *http.Request) bool {
-							return r.URL.String() == u
-						})).Return(&http.Response{
-							StatusCode: statusCode,
-							Body:       ioutil.NopCloser(strings.NewReader(name)),
-						}, nil)
-					}(url)
-
-				}
-
-				resty.client = client
-
-				ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
-				go func() {
-					<-ctx.Done()
-					cancel()
-				}()
-
-				return context.TODO(), resty
-			},
+			setup:       getSetupFuncForAllSuccessTest(),
+		},
+		{
+			name:        "Test_Resty_Failed_Due_To_Interceptor_Error",
+			expectedErr: fmt.Errorf("interceptor returned with error"),
+			urls:        []string{"http://Test_Resty_Failure_1", "http://Test_Resty_Failure_2"},
+			setup:       getSetupFuncForInterceptorErrorTest(),
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			r := require.New(t)
-
 			ctx, resty := tt.setup(r, tt.name, tt.statusCode, tt.urls)
-
 			resty.DoGet(ctx, tt.urls...)
-
 			errs := resty.Wait()
-
+			if tt.expectedErr != nil && tt.expectedErr != context.DeadlineExceeded && len(errs) == 0 {
+				t.Fatalf("expected err: %v, got: %v", tt.expectedErr, errs)
+			}
 			for _, err := range errs {
 				// test it by predefined error variable instead of error message
-				if tt.exceptedErr != nil {
-
-					r.ErrorIs(err, tt.exceptedErr)
+				if tt.expectedErr != nil {
+					r.Errorf(err, tt.expectedErr.Error())
 				} else {
 					r.Equal(nil, err)
 				}
 			}
-
 		})
+	}
+}
+
+func getSetupFuncForCtxDeadlineExtendedTest() func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
+	return func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
+		r := New()
+		r.client = &mocks.Timeout{
+			Timeout: 1 * time.Second,
+		}
+		ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+		go func() {
+			<-ctx.Done()
+			cancel()
+		}()
+		return ctx, r
+	}
+}
+
+func getSetupFuncForAllSuccessTest() func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
+	return func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
+		resty := New().Then(func(req *http.Request, resp *http.Response, respBody []byte, cf context.CancelFunc, err error) error {
+			ra.Equal(200, resp.StatusCode)
+			ra.Equal(nil, err)
+			ra.Equal(name, string(respBody))
+			return nil
+		})
+
+		client := &mocks.Client{}
+		setupMockClient(client, urls, statusCode, name)
+		resty.client = client
+
+		ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+		go func() {
+			<-ctx.Done()
+			cancel()
+		}()
+		return context.TODO(), resty
+	}
+}
+
+func getSetupFuncForInterceptorErrorTest() func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
+	return func(ra *require.Assertions, name string, statusCode int, urls []string) (context.Context, *Resty) {
+		opts := make([]Option, 0)
+		opts = append(opts, WithRequestInterceptor(func(r *http.Request) error {
+			return fmt.Errorf("interceptor returned with error") //nolint
+		}))
+		// create a resty object with an interceptor which returns an error
+		resty := New(opts...).Then(func(req *http.Request, resp *http.Response, respBody []byte, cf context.CancelFunc, err error) error {
+			return nil
+		})
+
+		client := &mocks.Client{}
+		setupMockClient(client, urls, statusCode, name)
+		resty.client = client
+
+		ctx, cancel := context.WithTimeout(context.TODO(), 3*time.Second)
+		go func() {
+			<-ctx.Done()
+			cancel()
+		}()
+		return context.TODO(), resty
+	}
+}
+
+func setupMockClient(mck *mocks.Client, urls []string, statusCode int, name string) {
+	for _, url := range urls {
+		func(u string) {
+			mck.On("Do", mock.MatchedBy(func(r *http.Request) bool {
+				return r.URL.String() == u
+			})).Return(&http.Response{
+				StatusCode: statusCode,
+				Body:       ioutil.NopCloser(strings.NewReader(name)),
+			}, nil)
+		}(url)
 	}
 }

--- a/core/transaction/utils.go
+++ b/core/transaction/utils.go
@@ -35,7 +35,6 @@ func NewOptimisticVerifier(sharders []string) *OptimisticVerifier {
 	transport := createTransport(resty.DefaultDialTimeout)
 
 	options := []resty.Option{
-		resty.WithTimeout(resty.DefaultRequestTimeout),
 		resty.WithRetry(resty.DefaultRetry),
 		resty.WithHeader(header),
 		resty.WithTransport(transport),
@@ -346,7 +345,6 @@ func VerifyTransactionTrusted(txnHash string, sharders []string) (*Transaction, 
 	transport := createTransport(resty.DefaultDialTimeout)
 
 	options := []resty.Option{
-		resty.WithTimeout(resty.DefaultRequestTimeout),
 		resty.WithRetry(resty.DefaultRetry),
 		resty.WithHeader(header),
 		resty.WithTransport(transport),

--- a/sdks/zbox.go
+++ b/sdks/zbox.go
@@ -114,7 +114,6 @@ func (z *ZBox) DoPost(req *Request, handle resty.Handle) *resty.Resty {
 	opts := make([]resty.Option, 0, 5)
 
 	opts = append(opts, resty.WithRetry(resty.DefaultRetry))
-	opts = append(opts, resty.WithTimeout(resty.DefaultRequestTimeout))
 	opts = append(opts, resty.WithRequestInterceptor(func(r *http.Request) error {
 		return z.SignRequest(r, req.AllocationID) //nolint
 	}))

--- a/zboxcore/sdk/playlist.go
+++ b/zboxcore/sdk/playlist.go
@@ -63,7 +63,6 @@ func getPlaylistFromBlobbers(ctx context.Context, alloc *Allocation, query strin
 	opts := make([]resty.Option, 0, 3)
 
 	opts = append(opts, resty.WithRetry(resty.DefaultRetry))
-	opts = append(opts, resty.WithTimeout(resty.DefaultRequestTimeout))
 	opts = append(opts, resty.WithRequestInterceptor(func(req *http.Request) error {
 		req.Header.Set("X-App-Client-ID", client.GetClientID())
 		req.Header.Set("X-App-Client-Key", client.GetClientPublicKey())
@@ -145,7 +144,6 @@ func getPlaylistFileFromBlobbers(ctx context.Context, alloc *Allocation, query s
 	opts := make([]resty.Option, 0, 3)
 
 	opts = append(opts, resty.WithRetry(resty.DefaultRetry))
-	opts = append(opts, resty.WithTimeout(resty.DefaultRequestTimeout))
 	opts = append(opts, resty.WithRequestInterceptor(func(req *http.Request) error {
 		req.Header.Set("X-App-Client-ID", client.GetClientID())
 		req.Header.Set("X-App-Client-Key", client.GetClientPublicKey())

--- a/zcncore/transaction_query_base.go
+++ b/zcncore/transaction_query_base.go
@@ -119,7 +119,12 @@ func (tq *TransactionQuery) checkHealth(ctx context.Context, host string) error 
 	}
 
 	// check health
-	r := resty.New(resty.WithTimeout(5 * time.Second))
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+	r := resty.New()
 	requestUrl := tq.buildUrl(host, SharderEndpointHealthCheck)
 	logging.Info("zcn: check health ", requestUrl)
 	r.DoGet(ctx, requestUrl)
@@ -250,7 +255,12 @@ func (tq *TransactionQuery) FromAll(ctx context.Context, query string, handle Qu
 		urls = append(urls, tq.buildUrl(host, query))
 	}
 
-	r := resty.New(resty.WithTimeout(10 * time.Second))
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+	r := resty.New()
 	r.DoGet(ctx, urls...).
 		Then(func(req *http.Request, resp *http.Response, respBody []byte, cf context.CancelFunc, err error) error {
 			res := QueryResult{

--- a/zcncore/transaction_query_base.go
+++ b/zcncore/transaction_query_base.go
@@ -120,10 +120,7 @@ func (tq *TransactionQuery) checkHealth(ctx context.Context, host string) error 
 
 	// check health
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	go func() {
-		<-ctx.Done()
-		cancel()
-	}()
+	defer cancel()
 	r := resty.New()
 	requestUrl := tq.buildUrl(host, SharderEndpointHealthCheck)
 	logging.Info("zcn: check health ", requestUrl)
@@ -256,10 +253,7 @@ func (tq *TransactionQuery) FromAll(ctx context.Context, query string, handle Qu
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	go func() {
-		<-ctx.Done()
-		cancel()
-	}()
+	defer cancel()
 	r := resty.New()
 	r.DoGet(ctx, urls...).
 		Then(func(req *http.Request, resp *http.Response, respBody []byte, cf context.CancelFunc, err error) error {


### PR DESCRIPTION
### Changes
This PR makes the following enhancements/fixes following bugs in the resty package:
- It removes the custom timeout param that was being sent while creating resty object. The timeout will now be controlled by the API caller/client through the request context. However, a default timeout of 10s (DefaultRequestTimeout) is still there for requests which do not have any timeout set.
- Fixes a bug in the code where errors returned by the interceptor weren't getting returned to `resty.Wait()`
- Adds/modifies unit tests for resty's functionality

### Fixes
Fixes #737 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
