### PR TITLE
corrected the ActualFileSize attribute

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -835,7 +835,7 @@ func (a *Allocation) GetFileMeta(path string) (*ConsolidatedFileMeta, error) {
 		result.EncryptedKey = ref.EncryptedKey
 		result.CommitMetaTxns = ref.CommitMetaTxns
 		result.Collaborators = ref.Collaborators
-		result.ActualFileSize = ref.Size
+		result.ActualFileSize = ref.ActualSize
 		result.ActualNumBlocks = ref.NumBlocks
 		return result, nil
 	}


### PR DESCRIPTION
Background:
(*Allocation).GetFileMeta() returns JSONString having property ActualFileSize
Upon refresh at frontend, allocation.listDir() is invoked which returns JSONString containing list where each obj has property actual_size. At gosdk, this actual_size=ActualSize.
When file is uploaded & completed is called, allocation.getFileMeta() is called, where we don't get actual_size, but we receive ActualFileSize.
Issue: ActualFileSize is "Size" attribute, but we required "ActualSize" to be displayed at frontend. 