### PR TITLE
Fix dir create issue by checking name early

### DIFF
--- a/zboxcore/allocationchange/createdir.go
+++ b/zboxcore/allocationchange/createdir.go
@@ -28,14 +28,15 @@ func (d *DirCreateChange) ProcessChange(rootRef *fileref.Ref) (commitParams Comm
 	for i := 0; i < len(fields); i++ {
 		found := false
 		for _, child := range dirRef.Children {
-			ref, ok := child.(*fileref.Ref)
+			ref, ok := child.(*fileref.FileRef)
 			if !ok {
 				err = errors.New("invalid_ref: child node is not valid *fileref.Ref")
 				return
 			}
 
 			if ref.Name == fields[i] {
-				dirRef = ref
+
+				dirRef = &ref.Ref
 				found = true
 				break
 			}

--- a/zboxcore/allocationchange/createdir.go
+++ b/zboxcore/allocationchange/createdir.go
@@ -1,7 +1,7 @@
 package allocationchange
 
 import (
-	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -28,18 +28,20 @@ func (d *DirCreateChange) ProcessChange(rootRef *fileref.Ref) (commitParams Comm
 	for i := 0; i < len(fields); i++ {
 		found := false
 		for _, child := range dirRef.Children {
-			ref, ok := child.(*fileref.FileRef)
-			if !ok {
-				err = errors.New("invalid_ref: child node is not valid *fileref.Ref")
-				return
-			}
-
-			if ref.Name == fields[i] {
-
-				dirRef = &ref.Ref
+			if child.GetName() == fields[i] {
+				ref, ok := child.(*fileref.Ref)
+				if !ok {
+					err = fmt.Errorf(
+						"invalid_ref: Expected type *fileref.Ref but got %T for"+
+							" file name: %s, file path: %s, file type: %s",
+						child, child.GetName(), child.GetPath(), child.GetType())
+					return
+				}
+				dirRef = ref
 				found = true
 				break
 			}
+
 		}
 		if !found {
 			uid := util.GetSHA1Uuid(d.Uuid, fields[i])


### PR DESCRIPTION
### Changes
-

### Fixes
- This PR fixes filetype conversion issue. The issue aroused because the for loop iteration was iterating on all children which also contain file in it which gets into type conversion to `fileref.Ref` with actual type being `fileref.FileRef`, and thus running into error. 

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
