### PR TITLE
fail if directory already exists

### DIFF
--- a/zboxcore/sdk/dirworker.go
+++ b/zboxcore/sdk/dirworker.go
@@ -124,6 +124,10 @@ func (req *DirRequest) commitRequest(existingDirCount int) error {
 		go AddCommitRequest(commitReq)
 	}
 	wg.Wait()
+	
+	if len(commitReqs) == 0 {
+		return errors.New("directory_exists", "Directory already exists")
+	}
 
 	for _, commitReq := range commitReqs {
 		if commitReq.result != nil {


### PR DESCRIPTION
### Changes
-Show error, if there already exists a directory 

### Fixes
-https://github.com/0chain/zboxcli/issues/240
(createdir)

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
