### PR TITLE
Alloc.GetRefs() return slice of length 0 when file doesn't exist

### DIFF
--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -913,33 +913,31 @@ func TestAllocation_GetRefs(t *testing.T) {
 		ClientID:  mockClientId,
 		ClientKey: mockClientKey,
 	}
+	functionName := "TestAllocation_GetRefs"
 	t.Run("Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present", func(t *testing.T) {
 		a := &Allocation{
 			DataShards:   2,
 			ParityShards: 2,
 		}
-		tname := "Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present"
+		testCaseName := "Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present"
 		a.InitAllocation()
 		sdkInitialized = true
 		for i := 0; i < numBlobbers; i++ {
 			a.Blobbers = append(a.Blobbers, &blockchain.StorageNode{
-				ID:      tname + mockBlobberId + strconv.Itoa(i),
-				Baseurl: "TestAllocation_GetRefs" + tname + mockBlobberUrl + strconv.Itoa(i),
+				ID:      testCaseName + mockBlobberId + strconv.Itoa(i),
+				Baseurl: functionName + testCaseName + mockBlobberUrl + strconv.Itoa(i),
 			})
 		}
 
 		var mockClient = mocks.HttpClient{}
-		httpResponse := http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body: func() io.ReadCloser {
-				jsonFR, err := json.Marshal("")
-				require.NoError(t, err)
-				return ioutil.NopCloser(bytes.NewReader([]byte(jsonFR)))
-			}(),
-		}
 		zboxutil.Client = &mockClient
 		for i := 0; i < numBlobbers; i++ {
-			mockClient.On("Do", mock.Anything).Return(&httpResponse, nil)
+			body, err := json.Marshal(map[string]string{
+				"code":  "invalid_path",
+				"error": "invalid_path: ",
+			})
+			require.NoError(t, err)
+			setupMockHttpResponse(t, &mockClient, functionName, testCaseName, a, http.MethodGet, http.StatusBadRequest, body)
 		}
 		path := "/any_random_path.txt"
 		otr, err := a.GetRefs(path, "", "", "", "f", "regular", 0, 5)

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -899,6 +899,56 @@ func TestAllocation_downloadFile(t *testing.T) {
 	}
 }
 
+func TestAllocation_GetRefs(t *testing.T) {
+	const (
+		mockType       = "f"
+		mockActualHash = "mockActualHash"
+	)
+
+	var mockClient = mocks.HttpClient{}
+	zboxutil.Client = &mockClient
+
+	client := zclient.GetClient()
+	client.Wallet = &zcncrypto.Wallet{
+		ClientID:  mockClientId,
+		ClientKey: mockClientKey,
+	}
+	t.Run("Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present", func(t *testing.T) {
+		a := &Allocation{
+			DataShards:   2,
+			ParityShards: 2,
+		}
+		tname := "Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present"
+		a.InitAllocation()
+		sdkInitialized = true
+		for i := 0; i < numBlobbers; i++ {
+			a.Blobbers = append(a.Blobbers, &blockchain.StorageNode{
+				ID:      tname + mockBlobberId + strconv.Itoa(i),
+				Baseurl: "TestAllocation_GetRefs" + tname + mockBlobberUrl + strconv.Itoa(i),
+			})
+		}
+
+		var mockClient = mocks.HttpClient{}
+		httpResponse := http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body: func() io.ReadCloser {
+				jsonFR, err := json.Marshal("")
+				require.NoError(t, err)
+				return ioutil.NopCloser(bytes.NewReader([]byte(jsonFR)))
+			}(),
+		}
+		zboxutil.Client = &mockClient
+		for i := 0; i < numBlobbers; i++ {
+			mockClient.On("Do", mock.Anything).Return(&httpResponse, nil)
+		}
+		path := "/any_random_path.txt"
+		otr, err := a.GetRefs(path, "", "", "", "f", "regular", 0, 5)
+		require.NoError(t, err)
+		require.Equal(t, true, len(otr.Refs) == 0)
+
+	})
+}
+
 func TestAllocation_GetFileMeta(t *testing.T) {
 	const (
 		mockType       = "f"

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -928,9 +928,6 @@ func TestAllocation_GetRefs(t *testing.T) {
 				Baseurl: functionName + testCaseName + mockBlobberUrl + strconv.Itoa(i),
 			})
 		}
-
-		var mockClient = mocks.HttpClient{}
-		zboxutil.Client = &mockClient
 		for i := 0; i < numBlobbers; i++ {
 			body, err := json.Marshal(map[string]string{
 				"code":  "invalid_path",

--- a/zboxcore/sdk/filerefsworker.go
+++ b/zboxcore/sdk/filerefsworker.go
@@ -66,6 +66,7 @@ func (o *ObjectTreeRequest) GetRefs() (*ObjectTreeResult, error) {
 	for idx, oTreeResponse := range oTreeResponses {
 		oTreeResponseStatusCodes[idx] = oTreeResponse.statusCode
 		if oTreeResponse.err != nil {
+			l.Logger.Error("Error while getting file refs from blobber:", oTreeResponse.err)
 			continue
 		}
 		var similarFieldRefs []SimilarField
@@ -85,7 +86,7 @@ func (o *ObjectTreeRequest) GetRefs() (*ObjectTreeResult, error) {
 			hashRefsMap[hash] = oTreeResponse.oTResult
 		}
 	}
-	
+
 	if zboxutil.MajorStatusCode(oTreeResponseStatusCodes) == http.StatusBadRequest { //It should be http.StatusNotFound, but the blobber is returning 400 if the file not found
 		return &ObjectTreeResult{}, nil
 	}
@@ -133,7 +134,7 @@ func (o *ObjectTreeRequest) getFileRefs(oTR *oTreeResponse, bUrl string) {
 			}
 			return nil
 		} else {
-			return errors.New("response_error", fmt.Sprintf("got status %d", resp.StatusCode))
+			return errors.New("response_error", fmt.Sprintf("got status %d, err: %s", resp.StatusCode, respBody))
 		}
 	})
 	oTR.statusCode = respStatusCode

--- a/zboxcore/zboxutil/util.go
+++ b/zboxcore/zboxutil/util.go
@@ -309,3 +309,21 @@ func ScryptDecrypt(key, ciphertext []byte) ([]byte, error) {
 
 	return plaintext, nil
 }
+
+func MajorStatusCode(statusCodes []int) int {
+	statusCodeCount := make(map[int]int)
+	// Count frequency of each status code
+	for _, value := range statusCodes {
+		statusCodeCount[value] += 1
+	}
+	maxFreq := 0
+	var maxStatusCode int
+	// Iterate through the map and find the status code having highest frequency.
+	for statusCode, statusCodeFreq := range statusCodeCount {
+		if statusCodeFreq > maxFreq {
+			maxStatusCode = statusCode
+			maxFreq = statusCodeFreq
+		}
+	}
+	return maxStatusCode
+}


### PR DESCRIPTION
### Changes
- Add `StatusCode` in `oTreeResponse`; if the major blobbers are returning not found or bad request, then we return a slice of length 0 instead of a consensus error.

### Fixes
- Fix https://github.com/0chain/gosdk/issues/862

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
