### PR TITLE
Add test for allocation.GetRefs()

### DIFF
--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -899,6 +899,55 @@ func TestAllocation_downloadFile(t *testing.T) {
 	}
 }
 
+func TestAllocation_GetRefs(t *testing.T) {
+	const (
+		mockType       = "f"
+		mockActualHash = "mockActualHash"
+	)
+
+	var mockClient = mocks.HttpClient{}
+	zboxutil.Client = &mockClient
+
+	client := zclient.GetClient()
+	client.Wallet = &zcncrypto.Wallet{
+		ClientID:  mockClientId,
+		ClientKey: mockClientKey,
+	}
+	t.Run("Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present", func(t *testing.T) {
+		a := &Allocation{
+			DataShards:   2,
+			ParityShards: 2,
+		}
+		tname := "Test_Get_Refs_Returns_Slice_Of_Length_0_When_File_Not_Present"
+		a.InitAllocation()
+		sdkInitialized = true
+		for i := 0; i < numBlobbers; i++ {
+			a.Blobbers = append(a.Blobbers, &blockchain.StorageNode{
+				ID:      tname + mockBlobberId + strconv.Itoa(i),
+				Baseurl: "TestAllocation_GetRefs" + tname + mockBlobberUrl + strconv.Itoa(i),
+			})
+		}
+
+		var mockClient = mocks.HttpClient{}
+		httpResponse := http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body: func() io.ReadCloser {
+				jsonFR, err := json.Marshal("")
+				require.NoError(t, err)
+				return ioutil.NopCloser(bytes.NewReader([]byte(jsonFR)))
+			}(),
+		}
+		zboxutil.Client = &mockClient
+		for i := 0; i < numBlobbers; i++ {
+			mockClient.On("Do", mock.Anything).Return(&httpResponse, nil)
+		}
+		path := "/any_random_path.txt"
+		otr, err := a.GetRefs(path, "", "", "", "f", "regular", 0, 5)
+		require.NoError(t, err)
+		require.Equal(t, true, len(otr.Refs) == 0)
+
+	})
+}
 func TestAllocation_GetFileMeta(t *testing.T) {
 	const (
 		mockType       = "f"


### PR DESCRIPTION
GetRefs should return slice of length 0 when file is absent.

### Changes
- Add unit test for alloc.Getrefs()
### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
