### PR TITLE
Fix/EOF

### DIFF
--- a/zboxcore/sdk/chunked_upload_blobber.go
+++ b/zboxcore/sdk/chunked_upload_blobber.go
@@ -69,7 +69,8 @@ func (sb *ChunkedUploadBlobber) sendUploadRequest(
 		return nil
 	}
 
-	req, err := zboxutil.NewUploadRequestWithMethod(sb.blobber.Baseurl, su.allocationObj.Tx, body, su.httpMethod)
+	req, err := zboxutil.NewUploadRequestWithMethod(
+		sb.blobber.Baseurl, su.allocationObj.Tx, body, su.httpMethod)
 	if err != nil {
 		return err
 	}
@@ -91,7 +92,7 @@ func (sb *ChunkedUploadBlobber) sendUploadRequest(
 
 			if err != nil {
 				logger.Logger.Error("Upload : ", err)
-				return
+				return fmt.Errorf("Error while doing reqeust. Error %s", err), false
 			}
 
 			if resp.Body != nil {
@@ -103,7 +104,7 @@ func (sb *ChunkedUploadBlobber) sendUploadRequest(
 			respbody, err = ioutil.ReadAll(resp.Body)
 			if err != nil {
 				logger.Logger.Error("Error: Resp ", err)
-				return
+				return fmt.Errorf("Error while reading body. Error %s", err), false
 			}
 
 			latestRespMsg = string(respbody)

--- a/zboxcore/zboxutil/http.go
+++ b/zboxcore/zboxutil/http.go
@@ -741,7 +741,21 @@ func MakeSCRestAPICall(scAddress string, relativePath string, params map[string]
 func HttpDo(ctx context.Context, cncl context.CancelFunc, req *http.Request, f func(*http.Response, error) error) error {
 	// Run the HTTP request in a goroutine and pass the response to f.
 	c := make(chan error, 1)
-	go func() { c <- f(Client.Do(req.WithContext(ctx))) }()
+	go func() {
+		var err error
+		// indefinitely try if io.EOF error occurs. As per some research over google
+		// it occurs when client http tries to send byte stream in connection that is
+		// closed by the server
+		for {
+			err = f(Client.Do(req.WithContext(ctx)))
+			if errors.Is(err, io.EOF) {
+				continue
+			}
+			break
+		}
+		c <- err
+	}()
+
 	// TODO: Check cncl context required in any case
 	// defer cncl()
 	select {


### PR DESCRIPTION
### Changes
-

### Fixes
-  Tries to fix [EOF issue](https://github.com/0chain/gosdk/issues/889). The cause of EOF is unknown but it basically seems to be related to closed connection issue or issue with readLoop in net/http package. 
References:

1. https://github.com/googleapis/google-cloud-go/issues/7090
2. https://github.com/golang/go/issues/53472
3. https://stackoverflow.com/questions/17714494/golang-http-request-results-in-eof-errors-when-making-multiple-requests-successi

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
