### PR TITLE
feat: revoke share method mobile sdk 

### DIFF
--- a/mobilesdk/zbox/storage.go
+++ b/mobilesdk/zbox/storage.go
@@ -500,3 +500,18 @@ func CreateDir(allocationID, dirName string) error {
 	}
 	return a.CreateDir(dirName)
 }
+
+// RevokeShare revoke authTicket
+//
+//  ## Inputs
+//  - allocationID
+//  - path
+//  - refereeClientID
+func RevokeShare(allocationID, path, refereeClientID string) error {
+  a, err := getAllocation(allocationID)
+  if err != nil {
+    return err
+  }
+  return a.RevokeShare(path, refereeClientID)
+}
+


### PR DESCRIPTION
### Changes
``` go
func RevokeShare(allocationID, path, refereeClientID string) error
```
