### PR TITLE
Feature/add remotepath in sync command

### DIFF
--- a/mobilesdk/zbox/allocation.go
+++ b/mobilesdk/zbox/allocation.go
@@ -322,7 +322,7 @@ func (a *Allocation) GetDiff(lastSyncCachePath string, localRootPath string, loc
 	if err != nil {
 		return "", fmt.Errorf("invalid remote exclude path JSON. %v", err)
 	}
-	lFdiff, err := a.sdkAllocation.GetAllocationDiff(lastSyncCachePath, localRootPath, filterArray, exclPathArray)
+	lFdiff, err := a.sdkAllocation.GetAllocationDiff(lastSyncCachePath, localRootPath, filterArray, exclPathArray, "/")
 	if err != nil {
 		return "", fmt.Errorf("get allocation diff in sdk failed. %v", err)
 	}

--- a/wasmsdk/allocation.go
+++ b/wasmsdk/allocation.go
@@ -180,7 +180,7 @@ func getRemoteFileMap(allocationID string) ([]*fileResp, error) {
 		return nil, err
 	}
 
-	ref, err := allocationObj.GetRemoteFileMap(nil)
+	ref, err := allocationObj.GetRemoteFileMap(nil, "/")
 	if err != nil {
 		sdkLogger.Error(err)
 		return nil, err

--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -48,8 +48,9 @@ type FileDiff struct {
 	Type string `json:"type"`
 }
 
-func (a *Allocation) getRemoteFilesAndDirs(dirList []string, fMap map[string]FileInfo, exclMap map[string]int) ([]string, error) {
+func (a *Allocation) getRemoteFilesAndDirs(dirList []string, fMap map[string]FileInfo, exclMap map[string]int, remotePath string) ([]string, error) {
 	childDirList := make([]string, 0)
+	remotePath = strings.TrimRight(remotePath, "/")
 	for _, dir := range dirList {
 		ref, err := a.ListDir(dir)
 		if err != nil {
@@ -59,7 +60,8 @@ func (a *Allocation) getRemoteFilesAndDirs(dirList []string, fMap map[string]Fil
 			if _, ok := exclMap[child.Path]; ok {
 				continue
 			}
-			fMap[child.Path] = FileInfo{
+			relativePathFromRemotePath := strings.TrimPrefix(child.Path, remotePath) 
+			fMap[relativePathFromRemotePath] = FileInfo{
 				Size:         child.Size,
 				ActualSize:   child.ActualSize,
 				Hash:         child.Hash,
@@ -78,13 +80,13 @@ func (a *Allocation) getRemoteFilesAndDirs(dirList []string, fMap map[string]Fil
 	return childDirList, nil
 }
 
-func (a *Allocation) GetRemoteFileMap(exclMap map[string]int) (map[string]FileInfo, error) {
+func (a *Allocation) GetRemoteFileMap(exclMap map[string]int, remotepath string) (map[string]FileInfo, error) {
 	// 1. Iteratively get dir and files separately till no more dirs left
 	remoteList := make(map[string]FileInfo)
-	dirs := []string{"/"}
+	dirs := []string{remotepath}
 	var err error
 	for {
-		dirs, err = a.getRemoteFilesAndDirs(dirs, remoteList, exclMap)
+		dirs, err = a.getRemoteFilesAndDirs(dirs, remoteList, exclMap, remotepath)
 		if err != nil {
 			l.Logger.Error(err.Error())
 			break
@@ -283,7 +285,7 @@ func findDelta(rMap map[string]FileInfo, lMap map[string]FileInfo, prevMap map[s
 	return lFDiff
 }
 
-func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath string, localFileFilters []string, remoteExcludePath []string) ([]FileDiff, error) {
+func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath string, localFileFilters []string, remoteExcludePath []string, remotePath string) ([]FileDiff, error) {
 	var lFdiff []FileDiff
 	prevRemoteFileMap := make(map[string]FileInfo)
 	// 1. Validate localSycnCachePath
@@ -309,7 +311,7 @@ func (a *Allocation) GetAllocationDiff(lastSyncCachePath string, localRootPath s
 	exclMap := getRemoteExcludeMap(remoteExcludePath)
 
 	// 3. Get flat file list from remote
-	remoteFileMap, err := a.GetRemoteFileMap(exclMap)
+	remoteFileMap, err := a.GetRemoteFileMap(exclMap, remotePath)
 	if err != nil {
 		return lFdiff, errors.Wrap(err, "error getting list dir from remote.")
 	}
@@ -342,7 +344,7 @@ func (a *Allocation) SaveRemoteSnapshot(pathToSave string, remoteExcludePath []s
 
 	// Get flat file list from remote
 	exclMap := getRemoteExcludeMap(remoteExcludePath)
-	remoteFileList, err := a.GetRemoteFileMap(exclMap)
+	remoteFileList, err := a.GetRemoteFileMap(exclMap, "/")
 	if err != nil {
 		return errors.Wrap(err, "error getting list dir from remote.")
 	}

--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -60,7 +60,7 @@ func (a *Allocation) getRemoteFilesAndDirs(dirList []string, fMap map[string]Fil
 			if _, ok := exclMap[child.Path]; ok {
 				continue
 			}
-			relativePathFromRemotePath := strings.TrimPrefix(child.Path, remotePath) 
+			relativePathFromRemotePath := strings.TrimPrefix(child.Path, remotePath)
 			fMap[relativePathFromRemotePath] = FileInfo{
 				Size:         child.Size,
 				ActualSize:   child.ActualSize,


### PR DESCRIPTION
### Changes
-  Add option to getDiff from specific remotepath. Earlier it was always show diff from root. 
-  See https://0chain.slack.com/archives/G013NS35YF4/p1684821377104129

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli: https://github.com/0chain/zboxcli/pull/439
- zwalletcli:
- Other: ...
