### PR TITLE
fix download after updateallocation

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -1947,7 +1947,6 @@ func (a *Allocation) UpdateWithRepair(
 	setThirdPartyExtendable bool, fileOptionsParams *FileOptionsParameters,
 	statusCB StatusCallback,
 ) (string, error) {
-
 	if lock > math.MaxInt64 {
 		return "", errors.New("invalid_lock", "int64 overflow on lock value")
 	}
@@ -1959,12 +1958,13 @@ func (a *Allocation) UpdateWithRepair(
 	}
 	l.Logger.Info(fmt.Sprintf("allocation updated with hash: %s", hash))
 
+	var alloc *Allocation
 	if addBlobberId != "" {
 		l.Logger.Info("waiting for a minute for the blobber to be added to network")
 
 		deadline := time.Now().Add(1 * time.Minute)
 		for time.Now().Before(deadline) {
-			alloc, err := GetAllocation(a.ID)
+			alloc, err = GetAllocation(a.ID)
 			if err != nil {
 				l.Logger.Error("failed to get allocation")
 				return hash, err
@@ -1991,7 +1991,7 @@ repair:
 	}
 
 	if shouldRepair {
-		err := a.RepairAlloc(statusCB)
+		err := alloc.RepairAlloc(statusCB)
 		if err != nil {
 			return "", err
 		}

--- a/zboxcore/sdk/downloadworker.go
+++ b/zboxcore/sdk/downloadworker.go
@@ -603,9 +603,10 @@ func (req *DownloadRequest) attemptSubmitReadMarker(blobber *blockchain.StorageN
 		return fmt.Errorf("error creating download request: %w", err)
 	}
 
+	pathHash := fileref.GetReferenceLookup(req.allocationID, req.remotefilepath)
 	header := &DownloadRequestHeader{
 		Path:         req.remotefilepath,
-		PathHash:     req.remotefilepathhash,
+		PathHash:     pathHash,
 		ReadMarker:   rmData,
 		ConnectionID: req.connectionID,
 	}


### PR DESCRIPTION
### Changes

problem: after I try to update an allocation, if I try to download a file, I get error. 

this was working earlier because we are sending path hash. 

But in the optimize download PR we changed it and we are passing remotefilepath only.

Ideally the blobber should accepts should either of them. But because of a bug on the blobber side, passing pathhash only works.

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
