### PR TITLE
Silent the zcnbridge http request when --silent

### DIFF
--- a/zcnbridge/http/client.go
+++ b/zcnbridge/http/client.go
@@ -29,14 +29,15 @@ func CleanClient() *http.Client {
 }
 
 // NewRetryableClient creates default retryablehttp.Client with timeouts and embedded NewClient result.
-func NewRetryableClient() *retryablehttp.Client {
+func NewRetryableClient(verbose bool) *retryablehttp.Client {
 	client := retryablehttp.NewClient()
 	client.HTTPClient = &http.Client{
 		Transport: zboxutil.DefaultTransport,
 	}
-	//client.RetryWaitMax = RetryWaitMax
-	//client.RetryMax = RetryMax
-	//client.Logger = nil
+
+	if !verbose {
+		client.Logger = nil
+	}
 
 	return client
 }


### PR DESCRIPTION
### Changes
- Silent the verbose log when running zcnbridge commands when `--slient` is enabled in zwallet and zbox

### Fixes
- #1206

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
