### PR TITLE
Removed padding from the CryptoJS functions 

### DIFF
--- a/zcncore/wallet_base.go
+++ b/zcncore/wallet_base.go
@@ -1282,7 +1282,7 @@ func Decrypt(key, text string) (string, error) {
 func CryptoJsEncrypt(passphrase, message string) (string, error) {
 	o := openssl.New()
 
-	enc, err := o.EncryptBytes(pad(passphrase, 32, ","), []byte(message), openssl.DigestMD5Sum)
+	enc, err := o.EncryptBytes(passphrase, []byte(message), openssl.DigestMD5Sum)
 	if err != nil {
 		return "", err
 	}
@@ -1290,16 +1290,9 @@ func CryptoJsEncrypt(passphrase, message string) (string, error) {
 	return string(enc), nil
 }
 
-func pad(passphrase string, i int, symbol string) string {
-	if len(passphrase) < i {
-		return passphrase + strings.Repeat(symbol, i-len(passphrase))
-	}
-	return passphrase
-}
-
 func CryptoJsDecrypt(passphrase, encryptedMessage string) (string, error) {
 	o := openssl.New()
-	dec, err := o.DecryptBytes(pad(passphrase, 32, ","), []byte(encryptedMessage), openssl.DigestMD5Sum)
+	dec, err := o.DecryptBytes(passphrase, []byte(encryptedMessage), openssl.DigestMD5Sum)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR aims to fix this https://github.com/0chain/gosdk/issues/1298
Padding is been removed from CryptoJS functions.

### Changes
-

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
