### PR TITLE
Increase timeout while getting NewReferencePath Request

### DIFF
--- a/zboxcore/sdk/commitworker.go
+++ b/zboxcore/sdk/commitworker.go
@@ -111,7 +111,7 @@ func (commitreq *CommitRequest) processCommit() {
 		return
 	}
 
-	ctx, cncl := context.WithTimeout(context.Background(), (time.Second * 30))
+	ctx, cncl := context.WithTimeout(context.Background(), (time.Second * 60))
 	err = zboxutil.HttpDo(ctx, cncl, req, func(resp *http.Response, err error) error {
 		if err != nil {
 			l.Logger.Error("Ref path error:", err)
@@ -141,12 +141,16 @@ func (commitreq *CommitRequest) processCommit() {
 	})
 
 	if err != nil {
+		l.Logger.Error(fmt.Sprintf("New Path Reference request failed. Error is: %s, blobber: %s", err.Error(), commitreq.blobber.Baseurl))
 		commitreq.result = ErrorCommitResult(err.Error())
 		return
 	}
+	l.Logger.Debug("Got Reference Path Result in: ", time.Since(start).Milliseconds())
+
 	rootRef, err := lR.GetDirTree(commitreq.allocationID)
 
 	if err != nil {
+		l.Logger.Error("Error while getting dir tree for blobber", commitreq.blobber.Baseurl)
 		commitreq.result = ErrorCommitResult(err.Error())
 		return
 	}

--- a/zboxcore/sdk/commitworker.go
+++ b/zboxcore/sdk/commitworker.go
@@ -150,7 +150,7 @@ func (commitreq *CommitRequest) processCommit() {
 	rootRef, err := lR.GetDirTree(commitreq.allocationID)
 
 	if err != nil {
-		l.Logger.Error("Error while getting dir tree for blobber", commitreq.blobber.Baseurl)
+		l.Logger.Error("Error while getting dir tree for blobber: ", commitreq.blobber.Baseurl)
 		commitreq.result = ErrorCommitResult(err.Error())
 		return
 	}


### PR DESCRIPTION
Increase timeout while getting NewReferencePath Request
Add some log lines too. 

### Changes
-

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
