### PR TITLE
Fix sync in windows

### DIFF
--- a/zboxcore/sdk/sync.go
+++ b/zboxcore/sdk/sync.go
@@ -135,7 +135,9 @@ func addLocalFileList(root string, fMap map[string]FileInfo, dirList *[]string, 
 		if err != nil {
 			l.Logger.Error("getting relative path failed", err)
 		}
-		lPath = "/" + lPath
+		// Allocation paths are like unix, so we modify all the backslashes
+		// to forward slashes. File path in windows contain backslashes. 
+		lPath = "/" + strings.ReplaceAll(lPath, "\\", "/")
 		// Exclude
 		if _, ok := exclMap[lPath]; ok {
 			if info.IsDir() {


### PR DESCRIPTION
### Changes
- In Windows, the file path contains backslashes. Getdiff function in gosdk was wrongly distinguishing same file as different. 

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
