### PR TITLE
default nonce as 0 when http badrequest occurs

### DIFF
--- a/wasmsdk/bridge.go
+++ b/wasmsdk/bridge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/0chain/gosdk/zcnbridge"
 	"github.com/0chain/gosdk/zcnbridge/errors"
+	"github.com/0chain/gosdk/zcnbridge/log"
 	"github.com/0chain/gosdk/zcnbridge/transaction"
 	"github.com/0chain/gosdk/zcnbridge/wallet"
 	"github.com/0chain/gosdk/zcncore"
@@ -123,6 +124,7 @@ func getNotProcessedWZCNBurnEvents() string {
 		return errors.New("getNotProcessedWZCNBurnEvents", "failed to retreive last ZCN processed mint nonce").Error()
 	}
 
+	log.Logger.Debug("MintNonce = " + strconv.Itoa(int(mintNonce)))
 	burnEvents, err := bridge.QueryEthereumBurnEvents(strconv.Itoa(int(mintNonce)))
 	if err != nil {
 		return errors.Wrap("getNotProcessedWZCNBurnEvents", "failed to retreive WZCN burn events", err).Error()

--- a/zcncore/transaction_query.go
+++ b/zcncore/transaction_query.go
@@ -535,6 +535,11 @@ func GetInfoFromSharders(urlSuffix string, op int, cb GetInfoCallback) {
 
 	qr, err := tq.GetInfo(context.TODO(), urlSuffix)
 	if err != nil {
+		if qr != nil && op == OpGetMintNonce {
+			logging.Debug("OpGetMintNonce QueryResult error", "; Content = ",  qr.Content, "; Error = ", qr.Error.Error(), "; StatusCode = ", qr.StatusCode)
+			cb.OnInfoAvailable(op, qr.StatusCode, "", qr.Error.Error())
+			return
+		}
 		cb.OnInfoAvailable(op, StatusError, "", err.Error())
 		return
 	}


### PR DESCRIPTION
### Changes
- After making REST API call to get mint nonce for user, http status code 400 is considered as success and hence mint nonce is considered as 0.

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
