### PR TITLE
Removing Build mobile tag

### DIFF
--- a/mobilesdk/sdk/keys.go
+++ b/mobilesdk/sdk/keys.go
@@ -1,6 +1,3 @@
-//go:build mobile
-// +build mobile
-
 package sdk
 
 import (


### PR DESCRIPTION
Needed for importing mobile split key handler in ST