### PR TITLE
Use signature to generate point for PRE encryption

### DIFF
--- a/zboxcore/sdk/chunked_upload.go
+++ b/zboxcore/sdk/chunked_upload.go
@@ -383,11 +383,14 @@ func (su *ChunkedUpload) createEncscheme() encryption.EncryptionScheme {
 			return nil
 		}
 	} else {
-		mnemonic := client.GetClient().Mnemonic
-		if mnemonic == "" {
+		tag := "filetype:audio" // keep the tag the same as below
+		sig, err := client.Sign(tag)
+		if err != nil {
+			logger.Logger.Error("failed to sign PRE tag: ", err)
 			return nil
 		}
-		privateKey, err := encscheme.Initialize(mnemonic)
+
+		privateKey, err := encscheme.Initialize(sig)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
### Changes
- Use signature to generate point for PRE encryption. The `client.Sign()` will use primary key or call zauth to sign the `tag` accordingly to get the signature. Both cases will return the same signature for the wallet with the same client id.
 
### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
