### PR TITLE
Add write callback

### DIFF
--- a/wasmsdk/blobber.go
+++ b/wasmsdk/blobber.go
@@ -999,8 +999,9 @@ func upload(allocationID, remotePath string, fileBytes, thumbnailBytes []byte, w
 // 		- remotePath : remote path of the file
 // 		- authTicket : auth ticket of the file, if the file is shared
 // 		- lookupHash : lookup hash of the file, which is used to locate the file if remotepath and allocation id are not provided
+// 		- writeChunkFuncName : callback function name to write the chunk, if empty the function will return arrayBuffer otherwise will return nil
 
-func downloadBlocks(allocId string, remotePath, authTicket, lookupHash string, startBlock, endBlock int64) ([]byte, error) {
+func downloadBlocks(allocId string, remotePath, authTicket, lookupHash, writeChunkFuncName string, startBlock, endBlock int64) ([]byte, error) {
 
 	if len(remotePath) == 0 && len(authTicket) == 0 {
 		return nil, RequiredArg("remotePath/authTicket")
@@ -1018,37 +1019,54 @@ func downloadBlocks(allocId string, remotePath, authTicket, lookupHash string, s
 		statusBar = &StatusBar{wg: wg, totalBytesMap: make(map[string]int)}
 	)
 
-	pathHash := encryption.FastHash(remotePath)
-	fs, err := sys.Files.Open(pathHash)
-	if err != nil {
-		return nil, fmt.Errorf("could not open local file: %v", err)
-	}
+	var fh sys.File
+	if writeChunkFuncName == "" {
+		pathHash := encryption.FastHash(remotePath)
+		fs, err := sys.Files.Open(pathHash)
+		if err != nil {
+			return nil, fmt.Errorf("could not open local file: %v", err)
+		}
 
-	mf, _ := fs.(*sys.MemFile)
-	if mf == nil {
-		return nil, fmt.Errorf("invalid memfile")
+		mf, _ := fs.(*sys.MemFile)
+		if mf == nil {
+			return nil, fmt.Errorf("invalid memfile")
+		}
+		fh = mf
+		defer sys.Files.Remove(pathHash) //nolint
+	} else {
+		fh = jsbridge.NewFileCallbackWriter(writeChunkFuncName)
 	}
-
-	defer sys.Files.Remove(pathHash) //nolint
 
 	wg.Add(1)
 	if authTicket != "" {
-		err = alloc.DownloadByBlocksToFileHandlerFromAuthTicket(mf, authTicket, lookupHash, startBlock, endBlock, 100, remotePath, false, statusBar, true)
+		err = alloc.DownloadByBlocksToFileHandlerFromAuthTicket(fh, authTicket, lookupHash, startBlock, endBlock, 100, remotePath, false, statusBar, true, sdk.WithFileCallback(
+			func() {
+				fh.Close() //nolint:errcheck
+			},
+		))
 	} else {
 		err = alloc.DownloadByBlocksToFileHandler(
-			mf,
+			fh,
 			remotePath,
 			startBlock,
 			endBlock,
 			100,
 			false,
-			statusBar, true)
+			statusBar, true, sdk.WithFileCallback(
+				func() {
+					fh.Close() //nolint:errcheck
+				},
+			))
 	}
 	if err != nil {
 		return nil, err
 	}
 	wg.Wait()
-	return mf.Buffer, nil
+	var buf []byte
+	if mf, ok := fh.(*sys.MemFile); ok {
+		buf = mf.Buffer
+	}
+	return buf, nil
 }
 
 // getBlobbers get list of active blobbers, and format them as array json string

--- a/wasmsdk/demo/index.html
+++ b/wasmsdk/demo/index.html
@@ -821,7 +821,7 @@
       }
 
       objects.push({
-        //remotePath: path,
+        remotePath: path,
         downloadOp: 1,
         numBlocks: 0,
         downloadToDisk: true,
@@ -829,7 +829,7 @@
       let stringifiedArray = JSON.stringify(objects);
 
       try {
-        const results = await goWasm.sdk.multiDownload('', stringifiedArray, 'eyJjbGllbnRfaWQiOiIiLCJvd25lcl9pZCI6IjI2ZTIzMjFhZWMxZmEyZDY1NGQ1MDQ5OWY3ZjhmYWJhNjNkYWMxYTExYTQwZDU3NDJkNDAzMWJmMzEzMzAxMTYiLCJhbGxvY2F0aW9uX2lkIjoiMDAwMzAzOTA1MGI3ZDdiM2FlNmI3MGEwZTVjMWU4ZjRhOTkxNzc1YWJiOTQ2NjljMDg4YzczNzJlMzYwMzkyYiIsImZpbGVfcGF0aF9oYXNoIjoiYWEzODE0NTM2ZWI2OWQwNjU4ZWM0OTgyZmE3ZTIwM2I2ZGI2ZWExYmU4ZmMxODRiMWJhOTZhMTk3NmMwM2JlOCIsImFjdHVhbF9maWxlX2hhc2giOiIxMjUwMjJhZGRiZTIwZDNhOWUzYjcxZTA0NjUzZjY3YiIsImZpbGVfbmFtZSI6InVidW50dS0yMi4wNC40LWxpdmUtc2VydmVyLWFtZDY0LmlzbyIsInJlZmVyZW5jZV90eXBlIjoiZiIsImV4cGlyYXRpb24iOjAsInRpbWVzdGFtcCI6MTcxNjM3ODIxNiwiZW5jcnlwdGVkIjpmYWxzZSwic2lnbmF0dXJlIjoiYmEzNzQ1NzlmZTczZDc1MWIwMTNiMjM2NjUzZDRiMGYyYzNjZDJlYTMyNTFkODg0MmRiNWQxNTlhNjBiN2ExMiJ9', '')
+        const results = await goWasm.sdk.multiDownload('', stringifiedArray, '', '')
         console.log(JSON.stringify(results))
       } catch (e) {
         alert(e)

--- a/wasmsdk/player_file.go
+++ b/wasmsdk/player_file.go
@@ -66,7 +66,7 @@ func (p *FilePlayer) download(startBlock int64) {
 	}
 	fmt.Println("start:", startBlock, "end:", endBlock, "numBlocks:", p.numBlocks, "total:", p.playlistFile.NumBlocks)
 
-	data, err := downloadBlocks(p.allocationObj.ID, p.remotePath, p.authTicket, p.lookupHash, startBlock, endBlock)
+	data, err := downloadBlocks(p.allocationObj.ID, p.remotePath, p.authTicket, p.lookupHash, "", startBlock, endBlock)
 	// data, err := downloadBlocks2(int(startBlock), int(endBlock), p.allocationObj, p.remotePath)
 	if err != nil {
 		PrintError(err.Error())


### PR DESCRIPTION
### Changes
- Added support for write chunk callback for downloadBlocks, if empty will download in memory and return the buffer.
- WASM will invoke this function with uint8Array and offset so write callback should take the input in this order

### Fixes
-

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
