### PR TITLE
fix: fix slice init length

### DIFF
--- a/mobilesdk/zbox/storage.go
+++ b/mobilesdk/zbox/storage.go
@@ -870,7 +870,7 @@ func GetRemoteFileMap(allocationID string) (string, error) {
 		return "", err
 	}
 
-	fileResps := make([]*fileResp, len(ref))
+	fileResps := make([]*fileResp, 0, len(ref))
 	for path, data := range ref {
 		paths := strings.SplitAfter(path, "/")
 		var resp = fileResp{


### PR DESCRIPTION
### Changes

The intention here should be to initialize a slice with a capacity of  `len(ref)` rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW


### Fixes

 fix slice init length

### Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

### Associated PRs (Link as appropriate):
- blobber:
- 0chain:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
