### PR TITLE
Remove double forward slash as separator and enhance tests

### DIFF
--- a/core/conf/config_test.go
+++ b/core/conf/config_test.go
@@ -23,6 +23,7 @@ func TestLoadConfig(t *testing.T) {
 		reader.On("GetString", "chain_id").Return("")
 		reader.On("GetString", "verify_optimistic").Return("true")
 		reader.On("GetInt", "sharder_consensous").Return(0)
+		reader.On("GetString", "ethereum_node_url").Return("")
 
 		return reader
 
@@ -53,6 +54,7 @@ func TestLoadConfig(t *testing.T) {
 				reader.On("GetString", "chain_id").Return("")
 				reader.On("GetString", "verify_optimistic").Return("true")
 				reader.On("GetInt", "sharder_consensous").Return(0)
+				reader.On("GetString", "ethereum_node_url").Return("")
 
 				return reader
 			},
@@ -98,6 +100,7 @@ func TestLoadConfig(t *testing.T) {
 				reader.On("GetString", "chain_id").Return("")
 				reader.On("GetString", "verify_optimistic").Return("true")
 				reader.On("GetInt", "sharder_consensous").Return(0)
+				reader.On("GetString", "ethereum_node_url").Return("")
 
 				return reader
 			},
@@ -133,6 +136,7 @@ func TestLoadConfig(t *testing.T) {
 				reader.On("GetString", "chain_id").Return("")
 				reader.On("GetString", "verify_optimistic").Return("false")
 				reader.On("GetInt", "sharder_consensous").Return(0)
+				reader.On("GetString", "ethereum_node_url").Return("")
 
 				return reader
 			},

--- a/zboxcore/sdk/allocation_test.go
+++ b/zboxcore/sdk/allocation_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/0chain/gosdk/core/zcncrypto"
 	"github.com/0chain/gosdk/zboxcore/blockchain"
 	"github.com/0chain/gosdk/zboxcore/fileref"
-
 	"github.com/0chain/gosdk/zboxcore/zboxutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1338,7 +1337,7 @@ func TestAllocation_GetAuthTicket(t *testing.T) {
 
 				// mock GetFileMeta for private sharing validation
 				fileMeta, err := json.Marshal(&fileref.FileRef{
-					EncryptedKey: "EncryptedKey",
+					EncryptedKey: "", //the file should not be encrypted for this scenario so we need to have this field empty
 				})
 				require.NoError(t, err)
 				setupMockHttpResponse(t, mockClient, "TestAllocation_GetAuthTicket", testCaseName, a, http.MethodPost, http.StatusOK, fileMeta)
@@ -2421,7 +2420,7 @@ func getMockAuthTicket(t *testing.T) string {
 			Name: mockFileRefName,
 		},
 		ValidationRoot: "mock validation root",
-		EncryptedKey:   "encrypted key",
+		EncryptedKey:   "",
 	})
 	require.NoError(t, err)
 

--- a/zboxcore/zboxutil/util.go
+++ b/zboxcore/zboxutil/util.go
@@ -149,7 +149,7 @@ func RemoteClean(path string) string {
 	}
 	for r < n {
 		switch {
-		case path[r] == '/' || path[r] == '\\': //os.IsPathSeparator(path[r]):
+		case path[r] == '/': //os.IsPathSeparator(path[r]):
 			// empty path element
 			r++
 		case path[r] == '.' && (r+1 == n || path[r+1] == '/'): //os.IsPathSeparator(path[r+1])):
@@ -181,7 +181,7 @@ func RemoteClean(path string) string {
 				out.append('/') //(Separator)
 			}
 			// copy element
-			for ; r < n && !(path[r] == '/' || path[r] == '\\'); r++ { //!os.IsPathSeparator(path[r]); r++ {
+			for ; r < n && !(path[r] == '/'); r++ { //!os.IsPathSeparator(path[r]); r++ {
 				out.append(path[r])
 			}
 		}

--- a/znft/ethereum_wallet.go
+++ b/znft/ethereum_wallet.go
@@ -76,6 +76,7 @@ func (app *Znft) createSignedTransactionFromKeyStore(ctx context.Context) (*bind
 	return opts, nil
 }
 
+//lint:ignore U1000 Intentionally unused for now; will be implemented in a future task.
 func (app *Znft) createSignedTransactionFromKeyStoreWithGasPrice(ctx context.Context, gasLimitUnits uint64) (*bind.TransactOpts, error) { //nolint
 	client, err := CreateEthClient(app.cfg.EthereumNodeURL)
 	if err != nil {

--- a/znft/keystore.go
+++ b/znft/keystore.go
@@ -30,7 +30,7 @@ func DeleteAccount(homedir, address string) bool {
 	})
 
 	if err != nil && wallet == nil {
-		Logger.Error(fmt.Sprintf("failed to find account %s, error: %s", address, err))``
+		Logger.Error(fmt.Sprintf("failed to find account %s, error: %s", address, err))
 		return false
 	}
 
@@ -64,7 +64,7 @@ func AccountExists(homedir, address string) bool {
 	Logger.Info(
 		fmt.Sprintf("Account exists. Status: %s, Path: %s", status, url),
 	)
-	
+
 	return true
 }
 
@@ -79,7 +79,7 @@ func CreateKeyStorage(homedir, password string) error {
 	Logger.Info(
 		fmt.Sprintf("Created account: %s", account.Address.Hex()),
 	)
-	
+
 	return nil
 }
 
@@ -159,6 +159,6 @@ func ImportAccount(homedir, mnemonic, password string) (string, error) {
 	Logger.Info(
 		fmt.Sprintf("Imported account %s to path: %s\n", acc.Address.Hex(), acc.URL.Path),
 	)
-	
+
 	return acc.Address.Hex(), nil
 }

--- a/znft/keystore.go
+++ b/znft/keystore.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 
+	log "github.com/0chain/gosdk/zcnbridge/log"
 	hdw "github.com/0chain/gosdk/zcncore/ethhdwallet"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -30,7 +31,7 @@ func DeleteAccount(homedir, address string) bool {
 	})
 
 	if err != nil && wallet == nil {
-		Logger.Error(fmt.Sprintf("failed to find account %s, error: %s", address, err))
+		log.Logger.Error(fmt.Sprintf("failed to find account %s, error: %s", address, err))
 		return false
 	}
 
@@ -54,14 +55,14 @@ func AccountExists(homedir, address string) bool {
 	})
 
 	if err != nil && wallet == nil {
-		Logger.Error(fmt.Sprintf("failed to find account %s, error: %s", address, err))
+		log.Logger.Error(fmt.Sprintf("failed to find account %s, error: %s", address, err))
 		return false
 	}
 
 	status, _ := wallet.Status()
 	url := wallet.URL()
 
-	Logger.Info(
+	log.Logger.Info(
 		fmt.Sprintf("Account exists. Status: %s, Path: %s", status, url),
 	)
 
@@ -76,7 +77,7 @@ func CreateKeyStorage(homedir, password string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create keystore")
 	}
-	Logger.Info(
+	log.Logger.Info(
 		fmt.Sprintf("Created account: %s", account.Address.Hex()),
 	)
 
@@ -144,7 +145,7 @@ func ImportAccount(homedir, mnemonic, password string) (string, error) {
 	// 3. Find key
 	acc, err := ks.Find(account)
 	if err == nil {
-		Logger.Info(
+		log.Logger.Info(
 			fmt.Sprintf("Account already exists: %s\nPath: %s\n\n", acc.Address.Hex(), acc.URL.Path),
 		)
 		return acc.Address.Hex(), nil
@@ -156,7 +157,7 @@ func ImportAccount(homedir, mnemonic, password string) (string, error) {
 		return "", errors.Wrap(err, "failed to get import private key")
 	}
 
-	Logger.Info(
+	log.Logger.Info(
 		fmt.Sprintf("Imported account %s to path: %s\n", acc.Address.Hex(), acc.URL.Path),
 	)
 

--- a/znft/transaction.go
+++ b/znft/transaction.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+//lint:ignore U1000 Intentionally unused for now; will be implemented in a future task.
 func (app *Znft) createTransactionWithGasPrice(ctx context.Context, address string, pack []byte) (*bind.TransactOpts, error) { //nolint
 	gasLimitUnits, err := app.estimateGas(ctx, address, pack)
 	if err != nil {

--- a/znft/znft.go
+++ b/znft/znft.go
@@ -2,7 +2,6 @@ package znft
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/0chain/gosdk/core/logger"
@@ -156,6 +155,8 @@ func (app *Znft) constructStorageERC721(ctx context.Context, address string) (*s
 }
 
 // Used to create StorageERC721 with preliminary gas estimation
+
+//lint:ignore U1000 Intentionally unused for now; will be implemented in a future task.
 func (app *Znft) constructWithEstimation( //nolint
 	ctx context.Context,
 	address string,
@@ -182,6 +183,7 @@ func (app *Znft) createTransactOpts(ctx context.Context) (*bind.TransactOpts, er
 	return transaction, nil
 }
 
+//lint:ignore U1000 Intentionally unused for now; will be implemented in a future task.
 func (app *Znft) createTransactOptsWithEstimation( //nolint
 	ctx context.Context,
 	address, method string,


### PR DESCRIPTION
# Changes
- Remove \\ as a path separator from the RemoteClean method and fix tests

# Fixes in code
## Fixes in zboxcore/zboxutil/util.go

- This leaves out using only '/' character as the path separator, this was detected while testing the integration tests on the `rclone_zus` 

Remote (object-storage) paths in the 0Chain ecosystem are always POSIX-style—they must use forward slashes (/) regardless of the client OS.

Treating the Windows separator (\) as a directory delimiter inside RemoteClean was therefore:
- Incorrect behaviour on Windows clients
- Higher-level code already converts local Windows paths to remote form: [line 153 of [zboxcore/sdk/sync.go](https://github.com/0chain/gosdk/blob/staging/zboxcore/sdk/sync.go)]
By the time a string reaches RemoteClean, any remaining back-slashes are intended to be literal characters in the object key.

On Linux/macOS the function only recognised /, on Windows it also treated \.

Testing this change locally, we were able to pass the leadingSpace changes on [rclone_zus](https://github.com/0chain/rclone_zus) as attached
<img width="692" height="827" alt="image" src="https://github.com/user-attachments/assets/01f03613-c920-41c5-bef7-3ff3553dd7c4" />

# Fixes in tests
## 🔨 Fixes in core/conf/config_test.go

Added missing mock for ethereum_node_url configuration field to prevent test panics when the new field is accessed during config loading

## 🔨Fixes in zboxcore/sdk/allocation_test.go

Removed  EncryptedKey values from test mocks to ensure auth ticket tests properly validate unencrypted file scenarios without requiring referee encryption keys

# Fixes in znft/keystore.go

The "Logger" was unable to find the actual logger which was imported with `log "github.com/0chain/gosdk/zcnbridge/log"` which passes the tests now.

