### PR TITLE
added  preservePath option for Operation requests

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -343,6 +343,7 @@ type OperationRequest struct {
 	IsRepair       bool // Required for repair operation
 	IsWebstreaming bool
 	EncryptedKey   string
+	PreservePath   bool `json:"-"` //Required to preserve the original path fo the file, false if no value is provided
 
 	// Required for uploads
 	Workdir         string
@@ -1114,10 +1115,12 @@ func (a *Allocation) DoMultiOperation(operations []OperationRequest, opts ...Mul
 				break
 			}
 			op := operations[i]
-			op.RemotePath = strings.TrimSpace(op.RemotePath)
-			if op.FileMeta.RemotePath != "" {
-				op.FileMeta.RemotePath = strings.TrimSpace(op.FileMeta.RemotePath)
-				op.FileMeta.RemoteName = strings.TrimSpace(op.FileMeta.RemoteName)
+			if !op.PreservePath {
+				op.RemotePath = strings.TrimSpace(op.RemotePath)
+				if op.FileMeta.RemotePath != "" {
+					op.FileMeta.RemotePath = strings.TrimSpace(op.FileMeta.RemotePath)
+					op.FileMeta.RemoteName = strings.TrimSpace(op.FileMeta.RemoteName)
+				}
 			}
 			remotePath := op.RemotePath
 			parentPaths := GenerateParentPaths(remotePath)


### PR DESCRIPTION
# Changes
- Added backward-compatible option for preservation of paths for Operation requests

# Fixes
- Operations now can choose to preserve paths

# Why is this feature needed?
Certain operations require the original path to be preserved, the original path is mutilated by trimming spaces and characters.

Now if the requests wants to, it can preserve the path provided and if this toggle is enabled by the operation, we do not perform operations such as trimming the path.

This change was introduced while working on rclone_zus trailing path tests.

<b><ul>These changes are backwards compatible with the existing operations as can be seen in LOC 346 as `bool json:"-"`  just defaults to false when no value is provided by the request caller</b></ul>

#1 Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/gosdk/actions/workflows/system_tests.yml) to check for any regressions :clipboard:

<img width="864" height="654" alt="image" src="https://github.com/user-attachments/assets/a4cce491-9f8a-4d58-a4fa-e44712dea00e" />

## Analysis of Failures

- TestAllocation_DownloadFileToFileHandler Panic - <b>EXISTING ISSUE</b>

The panic in TestAllocation_DownloadFileToFileHandler is not related to recent changes. This is an existing issue caused by
  1. Root Cause: The panic occurs in GenerateOwnerSigningKey function at line 376 in zboxcore/sdk/blobber_operations.go
  2. Error: panic: runtime error: slice bounds out of range [:32] with capacity 0

- zcncore Build Failure - <b>EXISTING ISSUE</b>
The zcncore build failure is also not related to recent changes

Most other tests are passing (marked as ok or (cached)), which indicates the core functionality is working correctly.

### Associated PRs :
- [rclone_zus](https://github.com/0chain/rclone_zus) : [PR-link](https://github.com/0chain/rclone_zus/pull/15)
