### PR TITLE
Exposed functionality to initiate and cancel reapair for mobile

### DIFF
--- a/mobilesdk/sdk/sdk.go
+++ b/mobilesdk/sdk/sdk.go
@@ -30,6 +30,8 @@ import (
 
 var nonce = int64(0)
 
+var allocationIDRequired = errors.Errorf("Allocation ID is required")
+
 type Autorizer interface {
 	Auth(msg string) (string, error)
 }
@@ -325,6 +327,49 @@ func (s *StorageSDK) GetAllocationStats(allocationID string) (string, error) {
 func (s *StorageSDK) FinalizeAllocation(allocationID string) (string, error) {
 	hash, _, err := sdk.FinalizeAllocation(allocationID)
 	return hash, err
+}
+
+// RepairAllocation repair allocation
+//   - allocationID: allocation ID
+func (s *StorageSDK) RepairAllocation(allocationID string) error {
+	// Validate allocation ID
+	if allocationID == "" {
+		return allocationIDRequired
+	}
+
+	// Get allocation
+	alloc, err := sdk.GetAllocation(allocationID)
+	if err != nil {
+		return err
+	}
+
+	// returns an error if allocation is not found or caller is not the owner
+	if alloc.Owner != client.Id() {
+		return errors.Errorf("Allocation access denied for repair: %s", alloc.Owner)
+	}
+
+	// Call repair with nil StatusCallback (no progress updates for mobile, ios implementation provides statusUpdates)
+	return alloc.RepairAlloc(nil)
+}
+
+// CancelRepair cancel repair for allocation
+//   - allocationID: allocation ID
+func (s *StorageSDK) CancelRepair(allocationID string) error {
+	if allocationID == "" {
+		return allocationIDRequired
+	}
+
+	alloc, err := sdk.GetAllocation(allocationID)
+	if err != nil {
+		return err
+	}
+
+	//returns an error if allocation is not found or caller is not the owner
+	if alloc.Owner != client.Id() {
+		return errors.Errorf("Allocation access denied for cancelling the repair: %s", alloc.Owner)
+	}
+
+	return alloc.CancelRepair()
 }
 
 // CancelAllocation cancel allocation by ID


### PR DESCRIPTION
# Changes
- Exposed RepairAllocation and CancelRepair functions in mobilesdk to match the exposure in IOS via WASM

# Fixes
- Android apps can now initiate repair operations on storage allocations, this feature was missing compared to its IOS counterpart which used WASM to achieve the same functionality

**NOTE**:- We will not get progess updates as we are passing nil in the RepairAlloc function which is contrary to what is being done in WASM used by ios, if required in Android, we can implement that change as well later. 

## System Tests

The test for mobilesdk is successful on local as attached

<img width="634" height="202" alt="image" src="https://github.com/user-attachments/assets/24489fe4-0173-4f2a-b526-45be97140c54" />


Apart form the following legacy failures unrelated to gosdk mobile, there are no failures, the legacy failures are as follows:
 - TestAllocation_DownloadFileToFileHandler Panic - **EXISTING ISSUE**
 - 
<img width="812" height="96" alt="image" src="https://github.com/user-attachments/assets/46ecd83e-b969-4dd8-be55-b0362a7adbb1" />

The panic in TestAllocation_DownloadFileToFileHandler is not related to recent changes. This is an existing issue caused by

    - **Root Cause:** The panic occurs in GenerateOwnerSigningKey function at line 376 in zboxcore/sdk/blobber_operations.go
    - **Error:** panic: runtime error: slice bounds out of range [:32] with capacity 0
- zcncore Build Failure - **EXISTING ISSUE**
- 
<img width="553" height="73" alt="image" src="https://github.com/user-attachments/assets/342fc07d-893f-4f19-860f-019b150fc2b5" />

The zcncore build failure is also not related to recent changes.

## Pre-Requisites for integration

These changes must be locally tested by the android team and post a thumbs-up only, we can merge these changes.

