### PR TITLE
feat: implement WASM network caching to skip 0DNS calls on refresh

### DIFF
--- a/core/client/init_node.go
+++ b/core/client/init_node.go
@@ -130,6 +130,12 @@ func Init(ctx context.Context, cfg conf.Config) error {
 	//init packages
 	conf.InitClientConfig(&cfg)
 
+	// If miners and sharders are provided in the config, use them directly.
+	// Otherwise, fetch them from the network.
+	if len(cfg.Miners) > 0 && len(cfg.Sharders) > 0 {
+		return initNode(ctx, cfg, cfg.Miners, cfg.Sharders)
+	}
+
 	network, err := GetNetwork(ctx)
 	if err != nil {
 		logging.Error("Failed to get network details ", zap.Error(err), zap.Any("block_worker", cfg.BlockWorker))
@@ -173,6 +179,26 @@ func Init(ctx context.Context, cfg conf.Config) error {
 
 	onlineMiners := filterOnlineNodes(network.Miners)
 	onlineSharders := filterOnlineNodes(network.Sharders)
+
+	return initNode(ctx, cfg, onlineMiners, onlineSharders)
+}
+
+func initNode(ctx context.Context, cfg conf.Config, onlineMiners, onlineSharders []string) error {
+	var network *conf.Network
+	var err error
+
+	// if we have miners and sharders, we can use them directly
+	if len(onlineMiners) > 0 && len(onlineSharders) > 0 {
+		network = &conf.Network{
+			Miners:   onlineMiners,
+			Sharders: onlineSharders,
+		}
+	} else {
+		network, err = GetNetwork(ctx)
+		if err != nil {
+			return err
+		}
+	}
 
 	reqMiners := util.MaxInt(3, int(math.Ceil(float64(cfg.MinSubmit)*float64(len(network.Miners))/100)))
 	reqSharders := util.MinInt(len(network.Sharders), util.MaxInt(cfg.SharderConsensous, conf.DefaultSharderConsensous))

--- a/core/client/set.go
+++ b/core/client/set.go
@@ -51,6 +51,9 @@ type InitSdkOptions struct {
 	SharderConsensous       *int
 	ZboxHost                string
 	ZboxAppType             string
+
+	Miners   []string
+	Sharders []string
 }
 
 func init() {
@@ -381,17 +384,51 @@ func InitSDK(walletJSON string,
 }
 
 func InitSDKWithWebApp(params InitSdkOptions) error {
-	if params.MinConfirmation != nil && params.MinSubmit != nil && params.ConfirmationChainLength != nil && params.SharderConsensous != nil {
-		err := InitSDK(params.WalletJSON, params.BlockWorker, params.ChainID, params.SignatureScheme, params.Nonce, params.AddWallet, *params.MinConfirmation, *params.MinSubmit, *params.ConfirmationChainLength, *params.SharderConsensous)
+	if params.AddWallet {
+		wallet := zcncrypto.Wallet{}
+		err := json.Unmarshal([]byte(params.WalletJSON), &wallet)
 		if err != nil {
 			return err
 		}
-	} else {
-		err := InitSDK(params.WalletJSON, params.BlockWorker, params.ChainID, params.SignatureScheme, params.Nonce, params.AddWallet)
-		if err != nil {
-			return err
+
+		SetWallet(wallet)
+		SetSignatureScheme(params.SignatureScheme)
+		SetNonce(params.Nonce)
+		if params.TxnFee != nil {
+			SetTxnFee(uint64(*params.TxnFee))
 		}
 	}
+
+	var minConfirmation, minSubmit, confirmationChainLength, sharderConsensous int
+	if params.MinConfirmation != nil {
+		minConfirmation = *params.MinConfirmation
+	}
+	if params.MinSubmit != nil {
+		minSubmit = *params.MinSubmit
+	}
+	if params.ConfirmationChainLength != nil {
+		confirmationChainLength = *params.ConfirmationChainLength
+	}
+	if params.SharderConsensous != nil {
+		sharderConsensous = *params.SharderConsensous
+	}
+
+	err := Init(context.Background(), conf.Config{
+		BlockWorker:             params.BlockWorker,
+		SignatureScheme:         params.SignatureScheme,
+		ChainID:                 params.ChainID,
+		MinConfirmation:         minConfirmation,
+		MinSubmit:               minSubmit,
+		ConfirmationChainLength: confirmationChainLength,
+		SharderConsensous:       sharderConsensous,
+		Miners:                  params.Miners,
+		Sharders:                params.Sharders,
+	})
+
+	if err != nil {
+		return err
+	}
+	SetSdkInitialized(true)
 	conf.SetZboxAppConfigs(params.ZboxHost, params.ZboxAppType)
 	SetIsAppFlow(true)
 	return nil

--- a/core/conf/config.go
+++ b/core/conf/config.go
@@ -78,6 +78,9 @@ type Config struct {
 	SharderConsensous int          `json:"sharder_consensous"`
 	ZauthServer       string       `json:"zauth_server"`
 	V                 *viper.Viper `json:"-"`
+
+	Miners   []string `json:"miners"`
+	Sharders []string `json:"sharders"`
 }
 
 // LoadConfigFile load and parse SDK Config from file

--- a/wasmsdk/sdk.go
+++ b/wasmsdk/sdk.go
@@ -18,7 +18,9 @@ import (
 
 	"io"
 	"os"
+	"syscall/js"
 )
+
 
 var CreateObjectURL func(buf []byte, mimeType string) string
 
@@ -32,14 +34,20 @@ var CreateObjectURL func(buf []byte, mimeType string) string
 //   - zboxHost is the url of the 0box service
 //   - zboxAppType is the application type of the 0box service
 //   - sharderconsensous is the number of sharders to reach consensus
+//   - sharderconsensous is the number of sharders to reach consensus
 func initSDKs(chainID, blockWorker, signatureScheme string,
 	minConfirmation, minSubmit, confirmationChainLength int,
-	zboxHost, zboxAppType string, sharderConsensous int) error {
+	zboxHost, zboxAppType string, sharderConsensous int, refresh bool) error {
 
 	// Print the parameters beautified
-	fmt.Printf("{ chainID: %s, blockWorker: %s, signatureScheme: %s, minConfirmation: %d, minSubmit: %d, confirmationChainLength: %d, zboxHost: %s, zboxAppType: %s, sharderConsensous: %d }\n", chainID, blockWorker, signatureScheme, minConfirmation, minSubmit, confirmationChainLength, zboxHost, zboxAppType, sharderConsensous)
+	fmt.Printf("{ chainID: %s, blockWorker: %s, signatureScheme: %s, minConfirmation: %d, minSubmit: %d, confirmationChainLength: %d, zboxHost: %s, zboxAppType: %s, sharderConsensous: %d, refresh: %v }\n", chainID, blockWorker, signatureScheme, minConfirmation, minSubmit, confirmationChainLength, zboxHost, zboxAppType, sharderConsensous, refresh)
 
 	zboxApiClient.SetRequest(zboxHost, zboxAppType)
+
+	var miners, sharders []string
+	if !refresh {
+		miners, sharders = loadNetworkFromCache()
+	}
 
 	params := client.InitSdkOptions{
 		WalletJSON:              "{}",
@@ -54,6 +62,8 @@ func initSDKs(chainID, blockWorker, signatureScheme string,
 		ConfirmationChainLength: &confirmationChainLength,
 		ZboxHost:                zboxHost,
 		ZboxAppType:             zboxAppType,
+		Miners:                  miners,
+		Sharders:                sharders,
 	}
 
 	err := client.InitSDKWithWebApp(params)
@@ -62,8 +72,60 @@ func initSDKs(chainID, blockWorker, signatureScheme string,
 		return err
 	}
 
+	if refresh || len(miners) == 0 {
+		saveNetworkToCache()
+	}
+
 	sdk.SetWasm()
 	return nil
+}
+
+func loadNetworkFromCache() ([]string, []string) {
+	storage := js.Global().Get("localStorage")
+	if storage.IsNull() || storage.IsUndefined() {
+		return nil, nil
+	}
+	val := storage.Call("getItem", "zcn_network_info")
+	if val.IsNull() || val.IsUndefined() {
+		return nil, nil
+	}
+	jsonStr := val.String()
+	type networkInfo struct {
+		Miners   []string `json:"miners"`
+		Sharders []string `json:"sharders"`
+	}
+	var info networkInfo
+	if err := json.Unmarshal([]byte(jsonStr), &info); err != nil {
+		return nil, nil
+	}
+	return info.Miners, info.Sharders
+}
+
+func saveNetworkToCache() {
+	node, err := client.GetNode()
+	if err != nil {
+		return
+	}
+	network := node.Network()
+	if network == nil {
+		return
+	}
+	type networkInfo struct {
+		Miners   []string `json:"miners"`
+		Sharders []string `json:"sharders"`
+	}
+	info := networkInfo{
+		Miners:   network.Miners,
+		Sharders: network.Sharders,
+	}
+	data, err := json.Marshal(info)
+	if err != nil {
+		return
+	}
+	storage := js.Global().Get("localStorage")
+	if !storage.IsNull() && !storage.IsUndefined() {
+		storage.Call("setItem", "zcn_network_info", string(data))
+	}
 }
 
 // getVersion retrieve the sdk version


### PR DESCRIPTION
# [FEAT] WASM: Implement Cached Initialization to Skip 0DNS Calls on Refresh

## Summary
This PR introduces a caching mechanism for the WASM SDK to significantly improve initialization performance on page reloads. By storing network details (miners and sharders) in the browser's `localStorage`, the SDK can now initialize instantly without making a network call to the 0DNS (block worker) server.

## Changes

### Core Logic
- **[core/conf/config.go](cci:7://file:///d:/projects/zus/gosdk/core/conf/config.go:0:0-0:0)**: Added [Miners](cci:1://file:///d:/projects/zus/gosdk/core/client/init_node.go:41:0-47:1) and [Sharders](cci:1://file:///d:/projects/zus/gosdk/core/client/init_node.go:69:0-74:1) fields to the [Config](cci:2://file:///d:/projects/zus/gosdk/core/conf/config.go:45:0-83:1) struct to allow passing pre-defined network details.
- **[core/client/init_node.go](cci:7://file:///d:/projects/zus/gosdk/core/client/init_node.go:0:0-0:0)**: Refactored the [Init](cci:1://file:///d:/projects/zus/gosdk/core/client/init_node.go:118:0-183:1) and [initNode](cci:1://file:///d:/projects/zus/gosdk/core/client/init_node.go:185:0-287:1) functions to skip network discovery if [Miners](cci:1://file:///d:/projects/zus/gosdk/core/client/init_node.go:41:0-47:1) and [Sharders](cci:1://file:///d:/projects/zus/gosdk/core/client/init_node.go:69:0-74:1) are provided in the configuration.
- **[core/client/set.go](cci:7://file:///d:/projects/zus/gosdk/core/client/set.go:0:0-0:0)**: Updated [InitSDKWithWebApp](cci:1://file:///d:/projects/zus/gosdk/core/client/set.go:385:0-434:1) to pass these cached network details into the core initialization flow.

### WASM Layer
- **[wasmsdk/sdk.go](cci:7://file:///d:/projects/zus/gosdk/wasmsdk/sdk.go:0:0-0:0)**: 
    - Implemented [loadNetworkFromCache](cci:1://file:///d:/projects/zus/gosdk/wasmsdk/sdk.go:82:0-101:1) and [saveNetworkToCache](cci:1://file:///d:/projects/zus/gosdk/wasmsdk/sdk.go:103:0-128:1) using the browser's `localStorage` via `syscall/js`.
    - Updated [initSDKs](cci:1://file:///d:/projects/zus/gosdk/wasmsdk/sdk.go:26:0-80:1) to accept a new `refresh` (boolean) parameter. 
    - Logic: If `refresh` is false, it attempts to load from cache; if the cache is empty or `refresh` is true, it performs a standard network discovery and updates the cache.
- **[wasmsdk/proxy.go](cci:7://file:///d:/projects/zus/gosdk/wasmsdk/proxy.go:0:0-0:0)**: Updated the JavaScript binding for the [init](cci:1://file:///d:/projects/zus/gosdk/core/client/set.go:58:0-87:1) function to accommodate the new `refresh` parameter.

## Impact & Safety
- **Web App**: Page refreshes now initialize the SDK significantly faster with zero network overhead.
- **Mobile & Desktop**: **Zero impact.** The existing [InitSDK](cci:1://file:///d:/projects/zus/gosdk/core/client/set.go:326:0-383:1) entry point remains untouched, and the core logic gracefully falls back to standard discovery when cached fields are empty.
- **Backward Compatibility**: The new field additions to the [Config](cci:2://file:///d:/projects/zus/gosdk/core/conf/config.go:45:0-83:1) struct are non-breaking.

## How to Test
1. **Initial Load**: Observe a network request to the block worker's `/network` endpoint. Verify `zcn_network_info` is created in `localStorage`.
2. **Page Refresh**: Verify that the `/network` call is **not** made, and the SDK initializes successfully using the cache.
3. **Forced Refresh**: Call `sdk.init(..., true)` from JS. Verify that the SDK bypasses the cache and hits the network.

## Checklist
- [x] Implemented `localStorage` caching logic.
- [x] Added `refresh` flag support.
- [x] Optimized `core/client` to skip redundant DNS calls.
- [x] Verified zero impact on legacy `InitSDK` path.