### PR TITLE
fix(client): nil-guard NodeHolder.adjustNode — register unknown ids in stats

### DIFF
--- a/core/client/node.go
+++ b/core/client/node.go
@@ -94,8 +94,20 @@ func (h *NodeHolder) adjustNode(id string, res int) {
 		n = node
 	}
 
+	// Keep h.nodes and h.stats in lockstep. The "new id" path above falls
+	// through here without ever registering n in h.stats; that leaves an id in
+	// h.nodes with no stats entry, so the comparator below dereferences a nil
+	// *NodeStruct and panics — fatal for any process using this SDK (blobber,
+	// validator, wasm: the whole Go runtime exits).
+	// This happens whenever Fail()/Success() is called with a sharder URL that
+	// wasn't in the original holder (e.g. the live URL differs from the
+	// configured one after a scheme/host rewrite). Register it, and nil-guard
+	// the comparator so any pre-existing divergence can't crash the runtime.
+	h.stats[n.id] = n
+
 	i := sort.Search(len(nodes), func(i int) bool {
-		return h.stats[nodes[i]].weight < n.weight
+		s := h.stats[nodes[i]]
+		return s != nil && s.weight < n.weight
 	})
 	h.nodes = append(nodes[:i], append([]string{n.id}, nodes[i:]...)...)
 }

--- a/core/client/node_test.go
+++ b/core/client/node_test.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression: Fail()/Success() with an id that was not in the original holder
+// (e.g. a sharder URL that differs from the configured one after a host/scheme
+// rewrite) used to add the id to h.nodes WITHOUT an h.stats entry, so the next
+// adjustNode dereferenced a nil *NodeStruct and panicked — fatal for any
+// process using this SDK (blobber, validator, wasm: the whole Go runtime
+// exits, surfacing as 502s and consensus_failed on every read).
+func TestNodeHolder_AdjustUnregisteredIDNoPanic(t *testing.T) {
+	h := NewHolder([]string{"1", "2", "3"}, 2)
+
+	// The second of these used to panic before the fix.
+	h.Fail("https://new-sharder.example/sharder01")
+	h.Success("https://another-sharder.example/sharder01")
+	h.Fail("1")
+
+	// Every id in the ordered list must have a stats entry, else a future
+	// adjustNode crashes.
+	for _, id := range h.All() {
+		assert.NotNilf(t, h.stats[id], "node %q in h.nodes has no h.stats entry", id)
+	}
+}


### PR DESCRIPTION
## Problem
All 10 mainnet blobbers (`0chaindev/blobber:v1.20.2`, gosdk `v1.17.0-lfb-1`) are crash-looping (RestartCount 55–75) with:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: pc=0x8af108]
github.com/0chain/gosdk/core/client.(*NodeHolder).adjustNode.func1  node.go:98
sort.Search
github.com/0chain/gosdk/core/client.(*NodeHolder).adjustNode        node.go:97
github.com/0chain/gosdk/core/client.(*NodeHolder).Success           node.go:61
github.com/0chain/gosdk/core/client.MakeSCRestAPICallToSharder.func1 http.go:102
```

Each crash takes the blobber offline mid-request → nginx 502 on `writemarker/lock` → client gets `lock_consensus_not_met: Required consensus 6 got 5` → uploads/deletes fail on Vult.

## Root cause
When `Success()`/`Fail()` is called with a sharder id not present in the holder's `stats` map, `adjustNode` inserts the id into `h.nodes` but never registers it in `h.stats`. Every subsequent call then dereferences `h.stats[unknown-id]` → nil → SIGSEGV.

## Fix
Port of 9bd19e49 (`feat/enterprise-blobber`, `core/node/node.go`) to `core/client/node.go`:
- Register `n` in `h.stats` before the insert, keeping `h.nodes`/`h.stats` in lockstep
- Nil-guard the `sort.Search` comparator

## Test
`TestNodeHolder_AdjustUnregisteredIDNoPanic` — panics/FAILs on the old code, PASSes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)