### PR TITLE
perf(zcncore): 5s TTL cache for GetCurrentRound

### DIFF
--- a/zcncore/get_data.go
+++ b/zcncore/get_data.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/0chain/gosdk/core/block"
 	"github.com/0chain/gosdk/core/client"
@@ -408,7 +410,30 @@ func IsHardforkActivated(name string) (bool, error) {
 	return currentRound >= round, nil
 }
 
+// 5-second TTL cache for current round. WASM upload init fires
+// IsHardforkActive/GetCurrentRound once per blobber as the SDK walks the
+// blobber list — for a 12-blobber alloc, that's 12 sequential
+// /v1/current-round sharder calls (~3-4 s wasted before the first chunk
+// even leaves the browser). The chain advances only every ~500 ms, so
+// a 5 s cache is well within tolerance for the activation predicate.
+var (
+	currentRoundCacheMu       sync.Mutex
+	currentRoundCacheValue    int64
+	currentRoundCacheFetchedAt time.Time
+	currentRoundCacheTTL       = 5 * time.Second
+)
+
 func GetCurrentRound() (int64, error) {
+	currentRoundCacheMu.Lock()
+	if !currentRoundCacheFetchedAt.IsZero() &&
+		time.Since(currentRoundCacheFetchedAt) < currentRoundCacheTTL &&
+		currentRoundCacheValue > 0 {
+		v := currentRoundCacheValue
+		currentRoundCacheMu.Unlock()
+		return v, nil
+	}
+	currentRoundCacheMu.Unlock()
+
 	res, err := screstapi.MakeSCRestAPICall("", GET_CURRENT_ROUND, nil, "")
 	if err != nil {
 		return 0, err
@@ -419,6 +444,11 @@ func GetCurrentRound() (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error getting current round : %v", err)
 	}
+
+	currentRoundCacheMu.Lock()
+	currentRoundCacheValue = round
+	currentRoundCacheFetchedAt = time.Now()
+	currentRoundCacheMu.Unlock()
 
 	return round, nil
 }


### PR DESCRIPTION
## Summary
- WASM upload init fires \`IsHardforkActivated\` → \`GetCurrentRound\` once per blobber as the SDK walks the blobber list. For a 12-blobber allocation that's 12 sequential \`/v1/current-round\` sharder roundtrips, ~3–4 s wasted before the first upload chunk leaves the browser.
- The chain advances only every ~500 ms, so a 5 s in-memory TTL cache is well within tolerance for the hardfork-activation predicate while collapsing the burst into a single call.
- Mutex-guarded; no behavior change beyond removing duplicate calls within the TTL window.

## Repro / verification
- DevTools Network panel during a Vult/Blimp upload init shows 9+ sequential \`current-round\` requests today. With this change: exactly 1 per 5 s window.

## Test plan
- [ ] Build the WASM (\`./wasm_build.sh\`), drop into web-apps, repeat an upload, confirm only one \`current-round\` request in the Network panel.
- [ ] Verify \`IsHardforkActivated\` still returns correct true/false across the hardfork boundary (manually test on a node where current-round is near the activation round).
- [ ] Existing \`zcncore\` unit tests pass.