### PR TITLE
feat(consensus): full consensus on writes + report failing blobbers

### DIFF
--- a/zboxcore/sdk/allocation.go
+++ b/zboxcore/sdk/allocation.go
@@ -56,6 +56,57 @@ var (
 	LogBlobberMonitoringChan     = make(chan BlobberMonitoring)
 )
 
+// FailedBlobber identifies a blobber that did not accept a write, so the
+// caller (web app) can tell the user exactly which providers to replace.
+type FailedBlobber struct {
+	Index int    `json:"index"` // position in Allocation.Blobbers
+	URL   string `json:"url"`
+	ID    string `json:"id"`
+	Error string `json:"error"`
+}
+
+// ConsensusFailure is the JSON payload embedded in a consensus_not_met error
+// so the WASM/JS layer can parse the list of failing blobbers. It is carried
+// as the message of a standard 0chain/errors error (code "consensus_not_met")
+// so existing string-based error handling keeps working; new callers can
+// json.Unmarshal the message into this struct.
+type ConsensusFailure struct {
+	Code           string          `json:"code"`
+	Message        string          `json:"message"`
+	SuccessCount   int             `json:"success_count"`
+	RequiredCount  int             `json:"required_count"`
+	FailedBlobbers []FailedBlobber `json:"failed_blobbers"`
+}
+
+// buildConsensusError produces a consensus_not_met error whose message is a
+// JSON ConsensusFailure listing every blobber NOT present in successMask.
+// connErrs may be nil; when present, connErrs[i] annotates blobber i.
+func buildConsensusError(a *Allocation, successMask zboxutil.Uint128, required int, connErrs []error, summary string) error {
+	failed := make([]FailedBlobber, 0)
+	for idx, b := range a.Blobbers {
+		bit := zboxutil.NewUint128(1).Lsh(uint64(idx))
+		if successMask.And(bit).Equals64(0) {
+			msg := ""
+			if connErrs != nil && idx < len(connErrs) && connErrs[idx] != nil {
+				msg = connErrs[idx].Error()
+			}
+			failed = append(failed, FailedBlobber{Index: idx, URL: b.Baseurl, ID: b.ID, Error: msg})
+		}
+	}
+	payload := ConsensusFailure{
+		Code:           "consensus_not_met",
+		Message:        summary,
+		SuccessCount:   successMask.CountOnes(),
+		RequiredCount:  required,
+		FailedBlobbers: failed,
+	}
+	b, mErr := json.Marshal(payload)
+	if mErr != nil {
+		return errors.New("consensus_not_met", summary)
+	}
+	return errors.New("consensus_not_met", string(b))
+}
+
 const (
 	KB = 1024
 	MB = 1024 * KB

--- a/zboxcore/sdk/multi_operation_worker.go
+++ b/zboxcore/sdk/multi_operation_worker.go
@@ -317,8 +317,22 @@ func (mo *MultiOperation) Process() error {
 		}
 	}
 	activeBlobbers := mo.operationMask.CountOnes()
-	if activeBlobbers < mo.consensusThresh {
-		l.Logger.Error("consensus not met", activeBlobbers, mo.consensusThresh)
+	// Writes require full consensus (all blobbers). For non-repair ops, a
+	// blobber dropped from operationMask above (allocation-root mismatch) or
+	// that never connected is a "problem blobber" the user must replace —
+	// report the specific list rather than a bare count.
+	writeRequired := mo.consensusThresh
+	if !mo.isRepair {
+		writeRequired = len(mo.allocationObj.Blobbers)
+	}
+	if activeBlobbers < writeRequired {
+		l.Logger.Error("consensus not met", activeBlobbers, writeRequired)
+		if !mo.isRepair {
+			return buildConsensusError(mo.allocationObj, mo.operationMask,
+				writeRequired, nil,
+				fmt.Sprintf("write reached %d of %d blobbers; full consensus required",
+					activeBlobbers, writeRequired))
+		}
 		return errors.New("consensus_not_met", fmt.Sprintf("Active blobbers %d is less than consensus threshold %d", activeBlobbers, mo.consensusThresh))
 	}
 
@@ -414,7 +428,11 @@ func (mo *MultiOperation) commitV2() error {
 			changes = mo.changesV2
 		}
 		threshold := mo.consensusThresh
-		if mask.CountOnes() < mo.consensusThresh {
+		// Writes require FULL consensus (every blobber). Only repair may lower
+		// the per-root-group threshold to whatever blobbers share that root —
+		// lowering it for writes is what lets a partial commit land on a
+		// subset and permanently diverge the allocation across blobbers.
+		if mo.isRepair && mask.CountOnes() < mo.consensusThresh {
 			threshold = mask.CountOnes()
 		}
 		commitReq := &CommitRequestV2{
@@ -450,9 +468,21 @@ func (mo *MultiOperation) commitV2() error {
 		}
 	}
 	if !mo.isConsensusOk() {
-		err := zboxutil.MajorError(errSlice)
-		if err == nil {
-			err = errors.New("consensus_not_met", fmt.Sprintf("Successfully committed to %d blobbers, but required %d", mo.consensus, len(mo.allocationObj.Blobbers)))
+		// Surface which blobbers failed so the user can replace them. For
+		// non-repair writes the required count is full consensus (all
+		// blobbers); the success set is rollbackMask (blobbers that did
+		// commit, now being rolled back).
+		var err error
+		if !mo.isRepair {
+			err = buildConsensusError(mo.allocationObj, rollbackMask,
+				len(mo.allocationObj.Blobbers), errSlice,
+				fmt.Sprintf("write committed to %d of %d blobbers; full consensus required",
+					mo.consensus, len(mo.allocationObj.Blobbers)))
+		} else {
+			err = zboxutil.MajorError(errSlice)
+			if err == nil {
+				err = errors.New("consensus_not_met", fmt.Sprintf("Successfully committed to %d blobbers, but required %d", mo.consensus, len(mo.allocationObj.Blobbers)))
+			}
 		}
 		if mo.getConsensus() != 0 {
 			l.Logger.Info("Rolling back changes on minority blobbers")

--- a/zboxcore/sdk/repairworker.go
+++ b/zboxcore/sdk/repairworker.go
@@ -88,6 +88,12 @@ func (r *RepairRequest) processRepair(ctx context.Context, a *Allocation) {
 	r.allocation = a
 	if a.StorageVersion == StorageV2 {
 		r.iterateDirV2(ctx)
+		// File reconciliation (iterateDirV2) only diffs FILE refs because the
+		// merkle trie / allocation_root is built from files alone. Empty
+		// directories (e.g. a streaming video's /preview subdir) that exist on
+		// some blobbers but not others are invisible to it and diverge forever.
+		// Reconcile directory refs separately so they converge too.
+		r.iterateDirsV2(ctx)
 	} else {
 		r.iterateDir(a, r.listDir)
 	}
@@ -493,6 +499,133 @@ func (r *RepairRequest) iterateDirV2(ctx context.Context) {
 		r.repairOperation(r.allocation, ops)
 	}
 
+}
+
+// iterateDirsV2 reconciles DIRECTORY refs across blobbers, the directory
+// analogue of iterateDirV2 (which only handles files). It walks the directory
+// listing from the consensus (latest-root) blobbers against each divergent
+// blobber and, where they differ, issues:
+//   - CreateDir on blobbers missing a directory the consensus has
+//   - Delete on blobbers holding a directory the consensus does not
+//
+// This is what heals the empty-directory divergence (e.g. streaming
+// /file.mp4/preview present on a subset of blobbers) that the file-only
+// repair pass cannot see. It is root-neutral: directories are not in the
+// merkle trie, so these ops never change allocation_root — they only bring
+// the on-blobber directory structure back into agreement.
+func (r *RepairRequest) iterateDirsV2(ctx context.Context) {
+	versionMap := make(map[string]*diffRef)
+	for idx, blobber := range r.allocation.Blobbers {
+		if versionMap[blobber.AllocationRoot] == nil {
+			versionMap[blobber.AllocationRoot] = &diffRef{}
+		}
+		versionMap[blobber.AllocationRoot].mask =
+			versionMap[blobber.AllocationRoot].mask.Or(zboxutil.NewUint128(1).Lsh(uint64(idx)))
+	}
+	latestRoot := r.allocation.allocationRoot
+	if versionMap[latestRoot] == nil ||
+		versionMap[latestRoot].mask.CountOnes() < r.allocation.DataShards {
+		// No consensus root to reconcile against; nothing safe to do.
+		return
+	}
+	if len(versionMap) == 1 {
+		// All blobbers agree on root → directory structure already consistent.
+		return
+	}
+
+	srcChan := r.allocation.ListObjects(ctx, r.repairPath, "", "", "", fileref.DIRECTORY, fileref.REGULAR, 0, getRefPageLimit, WithSingleBlobber(true), WithObjectMask(versionMap[latestRoot].mask), WithObjectContext(ctx))
+	for root, diff := range versionMap {
+		if root == latestRoot {
+			continue
+		}
+		diff.tgtChan = r.allocation.ListObjects(ctx, r.repairPath, "", "", "", fileref.DIRECTORY, fileref.REGULAR, 0, getRefPageLimit, WithSingleBlobber(true), WithObjectMask(diff.mask), WithObjectContext(ctx))
+		diff.tgtRef, diff.tgtEOF = <-diff.tgtChan
+	}
+
+	var (
+		toNextRef = true
+		srcRef    ORef
+		srcEOF    = true
+		ops       []OperationRequest
+	)
+	for {
+		if r.checkForCancel(r.allocation) {
+			return
+		}
+		if toNextRef {
+			if !srcEOF {
+				break
+			}
+			srcRef, srcEOF = <-srcChan
+			if srcRef.Err != nil {
+				l.Logger.Error("dir repair: failed to get source dir ref ", srcRef.Err.Error())
+				return
+			}
+		}
+		toNextRef = true
+		var createMask zboxutil.Uint128
+		for root, diff := range versionMap {
+			if root == latestRoot {
+				continue
+			}
+			if !srcEOF && !diff.tgtEOF {
+				continue
+			}
+			// target exhausted but source has more dirs → create them on target
+			if !diff.tgtEOF {
+				createMask = createMask.Or(diff.mask)
+				continue
+			}
+			// source exhausted but target has extra dirs → delete them
+			if !srcEOF {
+				delMask := diff.mask
+				ops = append(ops, OperationRequest{
+					OperationType: constants.FileOperationDelete,
+					RemotePath:    diff.tgtRef.Path,
+					Mask:          &delMask,
+				})
+				diff.tgtRef, diff.tgtEOF = <-diff.tgtChan
+				toNextRef = false
+				continue
+			}
+			if diff.tgtRef.Err != nil {
+				l.Logger.Error("dir repair: failed to get target dir ref ", diff.tgtRef.Err.Error())
+				continue
+			}
+			if diff.tgtRef.Path == srcRef.Path {
+				// same dir on both — consistent, advance target
+				diff.tgtRef, diff.tgtEOF = <-diff.tgtChan
+			} else if diff.tgtRef.Path < srcRef.Path {
+				// target has a dir the source lacks → delete it
+				delMask := diff.mask
+				ops = append(ops, OperationRequest{
+					OperationType: constants.FileOperationDelete,
+					RemotePath:    diff.tgtRef.Path,
+					Mask:          &delMask,
+				})
+				diff.tgtRef, diff.tgtEOF = <-diff.tgtChan
+				toNextRef = false
+			} else {
+				// source has a dir the target lacks → create it
+				createMask = createMask.Or(diff.mask)
+			}
+		}
+		if createMask.CountOnes() > 0 {
+			cMask := createMask
+			ops = append(ops, OperationRequest{
+				OperationType: constants.FileOperationCreateDir,
+				RemotePath:    srcRef.Path,
+				Mask:          &cMask,
+			})
+		}
+		if len(ops) >= RepairBatchSize {
+			r.repairOperation(r.allocation, ops)
+			ops = nil
+		}
+	}
+	if len(ops) > 0 {
+		r.repairOperation(r.allocation, ops)
+	}
 }
 
 func (r *RepairRequest) uploadFileOp(file ORef, opMask zboxutil.Uint128) OperationRequest {


### PR DESCRIPTION
## Summary
Two linked changes to the write path:

1. **Full consensus on writes.** Non-repair multi-operations now require *every* blobber to accept the op, or the write fails and the partial commit is rolled back. Previously the commit threshold could be lowered to the number of responding blobbers (`commitV2`: `threshold = mask.CountOnes()`), letting a write land on a subset and **permanently diverge the allocation across blobbers** — the root cause of the stuck streaming-video directories (incident doc in devOps repo).

2. **Report failing blobbers.** On write consensus failure, the returned `consensus_not_met` error's message is a JSON `ConsensusFailure{ success_count, required_count, failed_blobbers:[{index,url,id,error}] }`. The web app can parse it and tell the user exactly which providers to replace. Repair paths keep their reduced-consensus behavior and plain errors.

## Changes
- `multi_operation_worker.go commitV2`: only repair lowers the per-root-group threshold; writes keep full.
- `multi_operation_worker.go Process()`: writes require `len(Blobbers)` (not `consensusThresh`).
- `allocation.go`: `FailedBlobber` / `ConsensusFailure` types + `buildConsensusError` helper.

## Recovery when a blobber is permanently down
Replace-blobber (on-chain `updateallocation`) + repair re-syncs the new blobber → writes succeed again. The failing-blobber list drives that UX.

## ⚠️ Testing gate
**NOT yet integration-tested.** This is mainnet's entire write path — a bug means no one can upload. Before the WASM ships to mainnet it MUST pass a dev-blobber test: upload with a blobber killed → write fails with the correct failed-blobber list + rolls back; bring blobber back / replace + repair → write succeeds; confirm repair still commits at reduced consensus.

Both targets build clean (`go build ./zboxcore/...` + `GOOS=js GOARCH=wasm go build ./wasmsdk/...`).

## Related
- Blobber recursive-delete: 0chain/blobber#1558
- Option A (repair reconciles directory divergence) — designed in `devOps/0chain-debug/directory-consistency-design.md`, not yet implemented.