### PR TITLE
Port delete-consensus fixes to mainline (generic bug, not enterprise-only)

### DIFF
--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -359,10 +359,17 @@ func (req *DeleteRequest) ProcessDelete() (err error) {
 	// one of those still-not-updated replicas returns pre-delete content.
 	// Porcupine (2026-04-19) caught this as read-after-delete
 	// NON-LINEARIZABLE even though we wait for all 5 commits.
-	// Fix: after the commit succeeds, poll getFileMetaFromBlobber on each
-	// blobber until every one reports ErrNotFound (or a bounded timeout).
-	// Makes DoMultiOperation(DELETE) a synchronous read-after-delete
-	// barrier from the client's perspective.
+	//
+	// 2026-05-29 fix: the previous verifier polled `/v1/file/meta` per
+	// blobber via getFileMetaFromBlobber, but the gateway's subsequent
+	// GET path uses `alloc.GetRefs` (the `/v1/file/refs` endpoint, a
+	// different ref-index code path on the blobber). The two endpoints
+	// update on different timelines. Porcupine still flagged
+	// NON-LINEARIZABLE because: meta returns NotFound (verifier passes)
+	// while refs still returns the entry (GET sees stale value).
+	// We now poll BOTH endpoints — meta on every blobber AND GetRefs
+	// (which uses the consensus path the gateway GET uses) — until
+	// both are clear, or the timeout fires.
 	verifyStart := time.Now()
 	verifyTimeout := 5 * time.Second
 	verifyInterval := 20 * time.Millisecond
@@ -382,8 +389,20 @@ func (req *DeleteRequest) ProcessDelete() (err error) {
 			}(pos)
 		}
 		wgVerify.Wait()
+
+		// Additional check: the GetRefs endpoint (what the gateway's GET
+		// path queries via getSingleRegularRef → alloc.GetRefs) updates
+		// separately from /v1/file/meta. Confirm the entry is also gone
+		// from that view before declaring the DELETE complete.
 		if atomic.LoadInt32(&visible) == 0 {
-			break
+			level := len(strings.Split(strings.TrimSuffix(req.remotefilepath, "/"), "/"))
+			refsRes, refsErr := req.allocationObj.GetRefs(req.remotefilepath, "", "", "", "", "regular", level, 1)
+			refsVisible := refsErr == nil && refsRes != nil && len(refsRes.Refs) > 0
+			if !refsVisible {
+				// Both meta and refs agree the path is gone everywhere.
+				break
+			}
+			atomic.StoreInt32(&visible, 1)
 		}
 		if time.Since(verifyStart) > verifyTimeout {
 			l.Logger.Info("delete post-commit verification timed out; proceeding anyway",

--- a/zboxcore/sdk/deleteworker.go
+++ b/zboxcore/sdk/deleteworker.go
@@ -580,8 +580,14 @@ func (deleteReq *DeleteRequest) processDeleteV2() ([]fileref.RefEntity, zboxutil
 			defer deleteReq.wg.Done()
 			err := deleteReq.deleteBlobberFile(deleteReq.blobbers[blobberIdx], blobberIdx)
 			if err != nil {
+				// Do NOT count a failed blobber delete toward consensus, and do
+				// not evict the local ref cache. Previously consensus.Done() ran
+				// unconditionally, so an all-blobber failure (e.g. 507 disk_full)
+				// still satisfied isConsensusOk() and DoMultiOperation returned
+				// nil — a silent "success" that never removed the file.
 				logger.Logger.Error("error during deleteBlobberFile", err)
 				blobberErrors[blobberIdx] = err
+				return
 			}
 			deleteReq.consensus.Done()
 			if singleClientMode {


### PR DESCRIPTION
Ports two delete fixes from `feat/enterprise-blobber` to the mainline SDK branch (`fix/lfb-aware-sharder-selection`), which all web-apps + iOS + Android build from.

**Why:** both fixes live in `zboxcore/sdk/deleteworker.go`, which has **zero enterprise gating** (the delete code path is identical for normal wasm, enterprise wasm, and the mobile framework). The bugs are generic and the buggy code is present verbatim on the mainline tip — so Vult web + mobile carry them too, not just Blimp enterprise.

**Cherry-picked (original authorship preserved):**
- `36982f39` — close DELETE→GET race by polling `GetRefs` (not just `/v1/file/meta`) in the post-commit verifier. Bounded by the existing 5s timeout.
- `5060fe98` — do not count a failed (e.g. 507 disk_full) blobber delete toward consensus; previously `consensus.Done()` ran unconditionally so an all-blobber failure still satisfied `isConsensusOk()` and `DoMultiOperation` returned nil — a silent "success" that never removed the file.

**Scope:** additive guards in `deleteworker.go` only — no signature/API changes, no new bindings, nothing outside the delete path. `go build ./zboxcore/sdk/` passes; gofmt clean for the added lines (pre-existing alignment quirks left untouched).

Once merged, the next CI rebuild propagates these to zcn.wasm (Vult web) and the iOS/Android frameworks alongside lfb-3/lfb-4.